### PR TITLE
fix(portainer): untrack agent-tooling symlinks blocking Remote Stack deploys

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,0 @@
-../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 
 # openclaw config
 **/openclaw.json
+
+# Local agent-tooling shims (Portainer's git unpacker rejects symlinks).
+# Recreate locally with:
+#   ln -s AGENTS.md CLAUDE.md
+#   ln -s ../.agents/skills .claude/skills
+/CLAUDE.md
+/.claude/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,8 @@ See [Naming & Labeling Standards](../docs/naming_labels.md) for complete referen
 
 > Portainer services use local mount cloning the repo at `/mnt`.
 
+> **No symlinks in the repo.** Portainer's git unpacker rejects any tracked symlink (`exit 255: repository contains a symlink, which is not allowed for security reasons`), blocking every Remote Stack deploy. Local-only agent shims (e.g. `CLAUDE.md`, `.claude/skills`) must stay untracked via `.gitignore` — never `git add` a symlink.
+
 | Mount Type | `infra/` | `services/` |
 |------------|----------|-------------|
 | **Secrets** | File-based (`file:`) | External (pre-create on Pi) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md


### PR DESCRIPTION
## Summary
- Portainer's git unpacker refused every services/ Remote Stack deploy with `exit 255: repository contains a symlink, which is not allowed for security reasons`. Cause: commit fe7c1d6 introduced two tracked symlinks (`CLAUDE.md` → `AGENTS.md`, `.claude/skills` → `../.agents/skills`).
- Untrack both symlinks and add them to `.gitignore` — they remain on disk locally for Claude Code's legacy paths, but the repo is symlink-free so Portainer accepts it. No content duplication, no drift risk.
- Document the no-symlinks-in-repo constraint in `AGENTS.md` (Deployment section) so the rule is discoverable.

## Test plan
- [ ] Trigger a Portainer Remote Stack deploy from this branch and confirm the unpacker no longer errors.
- [ ] Verify local symlinks still resolve: `ls -la CLAUDE.md .claude/skills` (should show `lrwxr-xr-x` → `AGENTS.md` and `../.agents/skills`).
- [ ] Confirm `find . -type l -not -path './.git/*'` shows the symlinks locally but `git ls-files -s | awk '$1=="120000"'` returns nothing.

## Fresh-clone note
After a fresh clone, recreate the local shims manually (documented in `.gitignore`):
```
ln -s AGENTS.md CLAUDE.md
ln -s ../.agents/skills .claude/skills
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)