### PR TITLE
fix(shepherd): set tier label at service level so filter matches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,8 @@ service-name:
   # user: "<uid>:<gid>"
   deploy:
     <<: *deploy-base
+    labels:
+      com.giocaizzi.tier: "<tier>"        # service-level — required for Shepherd filter
     resources:
       limits:
         memory: <limit>M                # required for ARM64
@@ -197,6 +199,8 @@ service-name:
   logging:
     <<: *logging-base
 ```
+
+> **Tier label must appear in both blocks.** `labels:` (top-level) sets container labels; Shepherd filters on **service** labels via `docker service ls --filter` and needs `deploy.labels.com.giocaizzi.tier`. Omitting the deploy-level tier silently disables Shepherd auto-updates for that service.
 
 **Component values:** `app`, `data`, `worker`, `gateway`.
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -35,7 +35,7 @@ networks:
   public_network:
     external: true
     name: rp5_public
-  
+
   # Infrastructure internal network
   infra_network:
     external: true
@@ -85,6 +85,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "critical"
       resources:
         limits:
           memory: 128M
@@ -115,6 +117,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "extra"
       resources:
         limits:
           memory: 64M
@@ -144,12 +148,14 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "critical"
       resources:
         limits:
           memory: 256M
     logging:
       <<: *logging-base
-  
+
   # Cloudflare Tunnel
   tunnel:
     image: cloudflare/cloudflared:latest
@@ -176,6 +182,8 @@ services:
     read_only: true
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "critical"
       resources:
         limits:
           memory: 128M
@@ -221,6 +229,8 @@ services:
       com.giocaizzi.technology: "netdata"
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "critical"
       resources:
         limits:
           memory: 384M
@@ -260,6 +270,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "critical"
       resources:
         limits:
           memory: 512M
@@ -324,6 +336,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "critical"
       resources:
         limits:
           memory: 384M
@@ -360,6 +374,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "critical"
       resources:
         limits:
           memory: 64M
@@ -389,6 +405,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "critical"
       resources:
         limits:
           memory: 64M
@@ -418,6 +436,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "critical"
       resources:
         limits:
           memory: 64M
@@ -463,4 +483,3 @@ secrets:
     file: ./secrets/cert.pem
   ssl_key:
     file: ./secrets/key.pem
-

--- a/services/adguard/docker-compose.yml
+++ b/services/adguard/docker-compose.yml
@@ -87,6 +87,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 256M

--- a/services/ai/docker-compose.yml
+++ b/services/ai/docker-compose.yml
@@ -81,6 +81,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 4G
@@ -129,6 +131,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 1G

--- a/services/firefly/docker-compose.yml
+++ b/services/firefly/docker-compose.yml
@@ -122,6 +122,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 512M
@@ -160,6 +162,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 384M
@@ -196,6 +200,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "extra"
       resources:
         limits:
           memory: 64M
@@ -270,6 +276,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "extra"
       resources:
         limits:
           memory: 256M
@@ -312,6 +320,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "extra"
       resources:
         limits:
           memory: 64M

--- a/services/greenhouse/docker-compose.yml
+++ b/services/greenhouse/docker-compose.yml
@@ -130,6 +130,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "extra"
       resources:
         limits:
           memory: 512M

--- a/services/langfuse/docker-compose.yml
+++ b/services/langfuse/docker-compose.yml
@@ -170,6 +170,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 256M
@@ -221,6 +223,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 1024M
@@ -264,6 +268,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 256M
@@ -306,6 +312,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 128M
@@ -348,6 +356,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "extra"
       resources:
         limits:
           memory: 64M
@@ -391,6 +401,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "extra"
       resources:
         limits:
           memory: 64M
@@ -440,6 +452,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 512M
@@ -513,6 +527,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 512M

--- a/services/n8n/docker-compose.yml
+++ b/services/n8n/docker-compose.yml
@@ -80,6 +80,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 256M
@@ -121,6 +123,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "extra"
       resources:
         limits:
           memory: 64M
@@ -205,6 +209,8 @@ services:
     user: "1000:1000"
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 512M

--- a/services/ntfy/docker-compose.yml
+++ b/services/ntfy/docker-compose.yml
@@ -76,6 +76,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 256M

--- a/services/observability/docker-compose.yml
+++ b/services/observability/docker-compose.yml
@@ -109,6 +109,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 512M
@@ -141,6 +143,8 @@ services:
     user: "root"
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 512M
@@ -175,6 +179,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 512M
@@ -216,6 +222,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 256M
@@ -264,6 +272,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 256M

--- a/services/openclaw/docker-compose.yml
+++ b/services/openclaw/docker-compose.yml
@@ -100,6 +100,8 @@ services:
     <<: *security-base
     deploy:
       <<: *deploy-base
+      labels:
+        com.giocaizzi.tier: "core"
       resources:
         limits:
           memory: 512M


### PR DESCRIPTION
## Summary
- Shepherd was filtering on **service** labels but `com.giocaizzi.tier` was only set at **container** level — so every 24/48/72h cycle matched zero services and slept. Image timestamps showed most `:latest` images stale 2-5 months.
- Adds `deploy.labels.com.giocaizzi.tier` to every service across `infra/` + 9 service stacks (37 services, 10 compose files).
- Updates the service template in `AGENTS.md` to require the deploy-level tier and document the silent-failure mode.

## Why duplicate the tier label?
Docker Compose v3 puts top-level `services.<name>.labels` on the container, not the swarm service. Shepherd's `FILTER_SERVICES=label=...` queries swarm service labels. Without `deploy.labels`, the filter sees nothing and Shepherd is a no-op. Container-level labels are kept for `docker ps`-style inspection.

## Verified
- `docker compose -f <each> config -q` clean for all 10 files
- Branch: `fix/shepherd-service-labels` (37 services × 1 line each + AGENTS.md note)

## Test plan
- [ ] Merge to `main`
- [ ] `sync_infra.sh` to redeploy `infra` stack (Shepherd picks up new labels)
- [ ] Trigger Portainer redeploys for each service stack so `deploy.labels` are applied
- [ ] Verify `docker service inspect <name> --format '{{json .Spec.Labels}}'` includes `com.giocaizzi.tier`
- [ ] Wait one Shepherd cycle (or `docker service update --force infra_shepherd-critical` to kick) and confirm logs show service updates (no longer "Sleeping … before next update" with zero work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)