### PR TITLE
feat(firefly): add e2e runbook skill and persist OAuth keys

### DIFF
--- a/.claude/skills/firefly/SKILL.md
+++ b/.claude/skills/firefly/SKILL.md
@@ -1,109 +1,90 @@
 ---
 name: firefly
-description: Firefly runbook. Use this when working with Firefly app.
+description: End-to-end runbook for operating this Firefly III stack (personal finance manager deployed on the Pi). Use whenever the user asks about money, accounts, transactions, budgets, categories, tags, bills/subscriptions, piggy banks, recurring transactions, rules/rule-groups, reports, currencies, exchange rates, webhooks, attachments, imports (CSV, Lunch Flow, Spectre, Nordigen/GoCardless), exports, OAuth/Personal Access Tokens, integrity checks, DB rollbacks, or the firefly cron — even when they don't say "firefly". Covers the REST API (`/api/v1/*`), the artisan CLI (`php artisan firefly-iii:*`), the MariaDB schema, and the Data Importer.
 ---
 
-# Firefly
+# Firefly III runbook
 
-Firefly is a personal finance manager.
+Firefly III is a self-hosted personal finance manager. This skill covers running, scripting, and repairing the instance deployed in `services/firefly/`.
 
+## Stack at a glance
 
-## Firefly Database
+| Piece | Where |
+|---|---|
+| App | service `firefly_app`, container `firefly-app`, internal `http://firefly-app:8080` |
+| Database | service `firefly_db`, container `firefly-db`, MariaDB, DB `firefly`, user `firefly` |
+| Data Importer | service `firefly_importer`, container `firefly-importer`, internal `http://firefly-importer:8080` |
+| Scheduler | service `firefly_scheduler`, holds the `firefly_access_token` secret used by cron |
+| Public URL | `https://firefly.giocaizzi.xyz` (also `https://firefly.home` on LAN) |
+| Importer URL | `https://firefly-importer.home` |
 
-Firefly uses MariaDB for its database.
+Secrets live as external Swarm secrets (`firefly_*`). The app uses `_FILE` env vars; the importer uses the `load-secrets.sh` shim wrapped into the entrypoint. The Personal Access Token (long JWT) is in the `firefly_access_token` secret and is the credential for all CLI/API automation.
 
-### Database Structure
+**For secret rotation, deployment, volume layout, and initial setup, defer to `services/firefly/README.md`** — that is the operator's runbook. This skill covers what to do *with* a working Firefly instance, not how to stand one up or rotate its credentials.
 
-**Hierarchy:** `transaction_groups` → `transaction_journals` → `transactions`
+## How to drive Firefly
 
-Each transaction has:
-- **1 transaction_group** (parent) - groups related journals
-- **1 transaction_journal** - contains metadata (description, type, date)
-- **2+ transactions** - actual debit/credit entries (amount, account_id)
+Three surfaces. Pick the one that matches the task:
 
-**Soft-Delete Behavior:**
-- All three tables have `deleted_at` field (NULL = active, timestamp = deleted)
-- Firefly enforces parent-child consistency: if parent is soft-deleted, children are auto-deleted on restart
-- **Critical:** When restoring soft-deleted records, restore ALL levels (groups → journals → transactions)
+1. **REST API** (`/api/v1/*`, JSON-only) — best for CRUD on transactions/accounts/budgets/etc., reports, search, and webhooks. Authenticated with a Personal Access Token sent as `Authorization: Bearer <token>`. See `references/api.md`.
 
-**Transaction Types (transaction_type_id):**
-- 1 = Deposit
-- 2 = Invalid
-- 3 = Liability credit
-- 4 = Opening balance
-- 5 = Reconciliation
-- 6 = Transfer
-- 7 = Withdrawal
+2. **Artisan CLI** (`php artisan firefly-iii:*` inside the app container) — best for cron, bulk operations across users, exports, integrity checks, OAuth key recovery. See `references/cli.md`.
 
-**Rollback Pattern:**
-```sql
--- Always restore in this order:
-UPDATE transaction_groups SET deleted_at = NULL, updated_at = NOW()
-WHERE deleted_at IS NOT NULL AND EXISTS (
-  SELECT 1 FROM transaction_journals tj
-  WHERE tj.transaction_group_id = transaction_groups.id AND tj.description LIKE '%<pattern>%'
-);
-UPDATE transaction_journals SET deleted_at = NULL, updated_at = NOW()
-WHERE deleted_at IS NOT NULL AND description LIKE '%<pattern>%';
-UPDATE transactions t SET t.deleted_at = NULL, t.updated_at = NOW()
-WHERE t.deleted_at IS NOT NULL AND EXISTS (
-  SELECT 1 FROM transaction_journals tj
-  WHERE tj.id = t.transaction_journal_id AND tj.description LIKE '%<pattern>%'
-);
-```
+3. **Direct SQL** (MariaDB inside the db container) — last resort, only when API/CLI cannot recover. The schema has soft-delete semantics that must be respected. See `references/db.md`.
 
-**Post-restore commands (run in app container):**
-```bash
-php artisan cache:clear
-php artisan firefly-iii:correct-database
-php artisan firefly-iii:refresh-running-balance
-```
+Prefer API → CLI → SQL, in that order. Anything that mutates state via SQL must be followed by `php artisan firefly-iii:correct-database` and a cache flush (see `references/db.md`).
 
-**Connect to DB from app container (password via secret):**
-```bash
-APP=$(docker ps --filter 'label=com.docker.swarm.service.name=firefly_app' --format '{{.Names}}' | head -1)
-DB=$(docker ps --filter 'label=com.docker.swarm.service.name=firefly_db' --format '{{.Names}}' | head -1)
-DB_PASS=$(docker exec $APP cat /run/secrets/db_password)
-docker exec $DB mariadb -u firefly -p"$DB_PASS" firefly -e "SELECT ...;"
-```
+## Helper scripts
 
-## Updating the Importer Config
+Two thin wrappers in this skill's `scripts/` folder remove the SSH + secret-reading boilerplate:
 
-Swarm configs are immutable. Scale down first to release the lock, then recreate.
+- **`scripts/ff-api.sh`** — runs an authenticated curl against the app container. SSHes to the Pi, reads the token from the scheduler container's mounted secret, then `docker exec`s curl inside the app container. Usage:
+  ```bash
+  scripts/ff-api.sh GET  /api/v1/about
+  scripts/ff-api.sh GET  /api/v1/accounts?type=asset
+  scripts/ff-api.sh POST /api/v1/transactions @/path/to/payload.json
+  ```
+  No tokens leave the Pi. The body argument can be inline JSON, `@file.json`, or `-` for stdin.
 
-Scaling to 0 is **not** enough — the service definition still holds a reference. Use `--config-rm`/`--config-add` to detach/reattach.
+- **`scripts/ff-artisan.sh`** — runs `php artisan` inside the app container. Usage:
+  ```bash
+  scripts/ff-artisan.sh firefly-iii:cron
+  scripts/ff-artisan.sh firefly-iii:correct-database
+  scripts/ff-artisan.sh firefly-iii:report-integrity
+  scripts/ff-artisan.sh firefly-iii:export-data --token=... --export-transactions
+  ```
 
-```bash
-scp services/firefly/config/config.json pi@pi.local:/tmp/importer_config.json
-ssh pi@pi.local "
-  docker service update --config-rm firefly_importer_config firefly_importer &&
-  docker config rm firefly_importer_config &&
-  docker config create firefly_importer_config /tmp/importer_config.json &&
-  rm /tmp/importer_config.json &&
-  docker service update --config-add source=firefly_importer_config,target=/var/www/html/import/config.json,mode=0444 firefly_importer &&
-  docker service scale firefly_importer=1
-"
-```
+Both scripts honour `PI_SSH_USER` (default `giorgiocaizzi`) and `PI_HOST` (default `pi.local`), matching the convention used by `scripts/` at the repo root.
 
-> `config.json` is gitignored — contains `access_token`, never commit it.
+## When to read which reference
 
-## Triggering an Import Manually
+| Task | Read |
+|---|---|
+| Any HTTP call against Firefly (CRUD, charts, insight, summary, search, webhooks, attachments) | `references/api.md` |
+| Running cron, applying rules in bulk, exporting data, integrity reports, OAuth recovery, user mgmt | `references/cli.md` |
+| End-to-end recipes (create accounts → ingest CSV → tag → budget → reconcile → report) | `references/workflows.md` |
+| Soft-deletes, restoring transactions, fixing orphaned rows, schema cheat-sheet | `references/db.md` |
+| Lunch Flow / Spectre / GoCardless / CSV import via the Data Importer container, autoimport endpoint, config rotation | `references/importer.md` |
 
-The `/autoimport` endpoint requires an `Authorization: Bearer` header with the Firefly III personal access token (`firefly_access_token` secret). Read it from the scheduler container (which holds the secret), then POST to the importer:
+## Operating rules
 
-```bash
-ssh pi@pi.local "
-  SCHEDULER=\$(docker ps --filter 'label=com.docker.swarm.service.name=firefly_scheduler' --format '{{.Names}}' | head -1)
-  ACCESS_TOKEN=\$(docker exec \$SCHEDULER cat /run/secrets/firefly_access_token)
+- **Never log or echo the access token.** Read it inside the container (`cat /run/secrets/firefly_access_token`), pipe it into the request, do not capture it to local files.
+- **Read before writing.** For any destructive action (DELETE, `php artisan firefly-iii:correct-database`, SQL update), first `GET` the affected resource and confirm the IDs.
+- **The API URL is internal.** From outside the Pi, prefer `ff-api.sh` over hitting `https://firefly.giocaizzi.xyz` directly so the request stays on the overlay network and the token never crosses the public internet.
+- **Idempotency.** Set `error_if_duplicate_hash: true` on every transaction store to make replays safe; Firefly hashes the journal and rejects exact dupes with `422`.
+- **Rule fire-and-forget.** When creating/updating transactions, the default is `apply_rules: true, fire_webhooks: true`. Set to `false` for bulk migrations to avoid storms.
+- **Currency.** All amounts are decimal strings (`"12.34"`), never numbers. Mixing types silently rounds.
+- **Dates.** Firefly accepts both `YYYY-MM-DD` and full ISO-8601. Use ISO-8601 with explicit offset when timezone matters (e.g., recurring transactions stored UTC but displayed `Europe/Rome`).
+- **Pagination defaults.** Index endpoints return 50 items per page. Pass `?limit=N&page=N` and read `meta.pagination` to walk the rest. Maximum is 100 per page on most endpoints.
 
-  IMPORTER=\$(docker ps --filter 'label=com.docker.swarm.service.name=firefly_importer' --format '{{.Names}}' | head -1)
-  AUTO_IMPORT_SECRET=\$(docker exec \$IMPORTER cat /run/secrets/auto_import_secret)
+## Common failure modes (quick lookup)
 
-  docker exec \$IMPORTER curl -s -X POST \
-    -H 'Accept: application/json' \
-    -H \"Authorization: Bearer \${ACCESS_TOKEN}\" \
-    \"http://localhost:8080/autoimport?directory=/var/www/html/import&secret=\${AUTO_IMPORT_SECRET}\"
-"
-```
-
-Expected response: `{"message":"Seems to have worked!"}` (HTTP 200). Duplicate transaction errors in logs (`a115`) are non-fatal — they indicate already-imported data in the date range.
+| Symptom | Likely cause | Read |
+|---|---|---|
+| `401 Unauthenticated` | Token expired or wrong, or OAuth keys missing after restore | `references/cli.md` (`correction:restore-oauth-keys`) |
+| `422 Validation` with `transactions.0.amount` | Sent number instead of string, or missing `source_id`/`destination_id` | `references/api.md` (transaction shape) |
+| `422` with `a115` "duplicate hash" | Already imported — usually benign in importer logs | `references/importer.md` |
+| Running balance wrong after restore | Need to refresh balances | `references/db.md` |
+| Transactions vanished after manual SQL | Parent group/journal still soft-deleted; Firefly cascades | `references/db.md` (rollback pattern) |
+| Cron never fires | `STATIC_CRON_TOKEN` mismatch or scheduler container down | `references/cli.md` (`firefly-iii:cron`) |
+| Importer hangs after config swap | Swarm config lock — must detach/reattach | `references/importer.md` |

--- a/.claude/skills/firefly/references/api.md
+++ b/.claude/skills/firefly/references/api.md
@@ -1,0 +1,512 @@
+# Firefly III REST API reference
+
+Operational reference for the API exposed by `firefly_app` on `/api/v1`. Read this whenever you need to drive Firefly programmatically.
+
+Upstream: <https://api-docs.firefly-iii.org/>. Use this file first — it is tailored to *this* deployment and the typical workflows. Hit the upstream OpenAPI only when you need a field this file does not cover.
+
+## Table of contents
+- [1. Base, auth, content-type](#1-base-auth-content-type)
+- [2. Pagination, sorting, dates](#2-pagination-sorting-dates)
+- [3. Error model](#3-error-model)
+- [4. About, summary, search, autocomplete](#4-about-summary-search-autocomplete)
+- [5. Accounts](#5-accounts)
+- [6. Transactions](#6-transactions)
+- [7. Categories, tags, budgets, bills, piggy banks](#7-categories-tags-budgets-bills-piggy-banks)
+- [8. Recurrences](#8-recurrences)
+- [9. Rules and rule groups](#9-rules-and-rule-groups)
+- [10. Webhooks](#10-webhooks)
+- [11. Attachments, links, object-groups, preferences, configuration](#11-attachments-links-object-groups-preferences-configuration)
+- [12. Currencies and exchange rates](#12-currencies-and-exchange-rates)
+- [13. Charts, insight, reports](#13-charts-insight-reports)
+- [14. Data export, destroy, purge, bulk update](#14-data-export-destroy-purge-bulk-update)
+- [15. Users, user-groups, batch, system](#15-users-user-groups-batch-system)
+
+---
+
+## 1. Base, auth, content-type
+
+- **Base URL inside the swarm:** `http://firefly-app:8080/api/v1`
+- **Base URL from the public side:** `https://firefly.giocaizzi.xyz/api/v1`
+- **Auth:** `Authorization: Bearer <personal_access_token>`. The token is the Swarm secret `firefly_access_token`, mounted in `firefly-scheduler` at `/run/secrets/firefly_access_token`. To generate a new one: Firefly UI → Profile → OAuth → Personal Access Tokens.
+- **Required headers:** `Accept: application/vnd.api+json` (preferred) or `Accept: application/json` is accepted. `Content-Type: application/json` for `POST`/`PUT`.
+- **Scopes:** Personal Access Tokens have all scopes. OAuth clients (e.g. the Data Importer) need the `*` scope on creation.
+
+### Helper
+
+Use `scripts/ff-api.sh` from this skill's root — it handles SSH + token loading + container exec. Verbatim curl from the host looks like:
+
+```bash
+ssh giorgiocaizzi@pi.local '
+  SCHED=$(docker ps -qf "label=com.docker.swarm.service.name=firefly_scheduler" | head -1)
+  TOKEN=$(docker exec $SCHED cat /run/secrets/firefly_access_token)
+  APP=$(docker ps -qf "label=com.docker.swarm.service.name=firefly_app" | head -1)
+  docker exec $APP curl -sS \
+    -H "Accept: application/json" \
+    -H "Authorization: Bearer $TOKEN" \
+    http://localhost:8080/api/v1/about
+'
+```
+
+## 2. Pagination, sorting, dates
+
+- **Pagination:** `?page=1&limit=50`. Default 50, max usually 100. Response shape:
+  ```json
+  {
+    "data": [...],
+    "meta": {
+      "pagination": {"total": 1234, "count": 50, "per_page": 50, "current_page": 1, "total_pages": 25}
+    },
+    "links": {"self": "...", "first": "...", "next": "...", "last": "..."}
+  }
+  ```
+- **Iterating:** loop while `meta.pagination.current_page < meta.pagination.total_pages`.
+- **Date filters** on transactions/charts: `?start=YYYY-MM-DD&end=YYYY-MM-DD` (inclusive both ends).
+- **Sorting** is generally not exposed via query — order is server-default (date desc for transactions). Do client-side sort if needed.
+- **Single-resource fetch** ignores pagination.
+
+## 3. Error model
+
+| Status | Meaning |
+|---|---|
+| `200 OK` | Read success |
+| `204 No Content` | Delete success |
+| `401 Unauthenticated` | Missing/invalid bearer token, or OAuth keys missing |
+| `403 Unauthorized` | Token has no rights to this resource (cross-user) |
+| `404 Not Found` | Resource doesn't exist or is soft-deleted |
+| `422 Unprocessable Entity` | Validation failure — body has `message` and `errors` map |
+| `429 Too Many Requests` | Rare; mostly the cron endpoint and webhooks |
+| `500` | Server error — check `php artisan firefly-iii:report-integrity` and app logs |
+
+Validation responses look like:
+```json
+{
+  "message": "The given data was invalid.",
+  "errors": {
+    "transactions.0.amount": ["The amount must be a string."],
+    "transactions.0.source_id": ["The source id field is required when source name is not present."]
+  }
+}
+```
+
+Special application error codes appear in messages — most notable:
+- **`a115`** = "duplicate transaction hash". Returned when an identical transaction (same date+amounts+accounts) already exists. Not a bug; mark the import as idempotent.
+
+## 4. About, summary, search, autocomplete
+
+### `GET /about`
+System info — version, OS, PHP version, driver. Use as a health check (`firefly-app` healthcheck hits this).
+
+### `GET /about/user`
+Currently authenticated user (id, email, role).
+
+### `GET /summary/basic?start=YYYY-MM-DD&end=YYYY-MM-DD&currency_code=EUR`
+Dashboard cards: balance, net-worth, spent, earned, bills, all keyed by `<metric>-in-<CUR>` (e.g. `balance-in-EUR`). The fastest way to fetch the "top of dashboard" numbers.
+
+### `GET /search/transactions?query=<q>&page=N`
+Full-text + structured search. The query syntax mirrors the Firefly UI search bar: `amount:100`, `category:Groceries`, `tag:tax`, `account:"Main checking"`, `date:2026-01..2026-03`, `notes_contain:VISA`. Combine with spaces (AND).
+- `GET /search/transactions/count?query=<q>` returns just the count.
+- `GET /search/accounts?query=<q>&field=all` finds accounts by name/iban/number.
+
+### Autocomplete (`/autocomplete/*`)
+Lightweight name→id lookups for UI typeaheads, but very useful in scripts. All take `?query=<prefix>&limit=10`.
+- `/autocomplete/accounts?types=Asset%20account,Expense%20account&query=ama`
+- `/autocomplete/categories`, `/autocomplete/tags`, `/autocomplete/budgets`
+- `/autocomplete/bills` (= subscriptions), `/autocomplete/recurring`
+- `/autocomplete/rules`, `/autocomplete/rule-groups`
+- `/autocomplete/currencies`, `/autocomplete/currencies-with-code`
+- `/autocomplete/object-groups`, `/autocomplete/piggy-banks`, `/autocomplete/piggy-banks-with-balance`
+- `/autocomplete/transactions`, `/autocomplete/transactions-with-id`
+- `/autocomplete/transaction-types`
+
+When you need an ID and have a name, this is faster than walking the index.
+
+## 5. Accounts
+
+Account types: `asset`, `expense`, `revenue`, `liability` (with sub-types `loan`, `debt`, `mortgage`, `credit card`), `cash`, `initial-balance`, `reconciliation`.
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET`    | `/accounts?type=asset&limit=100&date=2026-05-17` | `type` filter optional; `date` is the as-of date for balance |
+| `POST`   | `/accounts` | Create — see body |
+| `GET`    | `/accounts/{id}` | One account with current balance |
+| `PUT`    | `/accounts/{id}` | Update — full or partial body |
+| `DELETE` | `/accounts/{id}` | Soft-delete; child transactions stay but become orphaned in UI |
+| `GET`    | `/accounts/{id}/transactions?type=withdrawal&start=..&end=..` | Tx for this account |
+| `GET`    | `/accounts/{id}/piggy-banks` | Piggy banks linked to this asset account |
+| `GET`    | `/accounts/{id}/attachments` | |
+
+**Store body (minimum):**
+```json
+{
+  "name": "Revolut EUR",
+  "type": "asset",
+  "currency_code": "EUR",
+  "account_role": "defaultAsset",
+  "opening_balance": "150.00",
+  "opening_balance_date": "2026-01-01",
+  "iban": "GB00REVO00000000000000",
+  "include_net_worth": true,
+  "active": true
+}
+```
+
+`account_role` values for asset accounts: `defaultAsset`, `sharedAsset`, `savingAsset`, `ccAsset`, `cashWalletAsset`. For credit cards add `credit_card_type` (`monthlyFull`) and `monthly_payment_date`.
+
+For liabilities the body adds `liability_type` (`loan`/`debt`/`mortgage`), `liability_direction` (`credit`=owed by user / `debit`=owed to user), `interest`, `interest_period`.
+
+## 6. Transactions
+
+The heart of the API. The model is **transaction group → transaction journal(s) → transactions (debit/credit pair)**, but the API hides this — you submit a *group* and Firefly creates the rest.
+
+### Endpoints
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET`    | `/transactions?type=all&start=..&end=..&limit=100&page=1` | Paginated list |
+| `POST`   | `/transactions` | Create — see body |
+| `GET`    | `/transactions/{groupId}` | One group with all journals |
+| `PUT`    | `/transactions/{groupId}` | Update — full replacement of `transactions[]` |
+| `DELETE` | `/transactions/{groupId}` | Soft-delete group |
+| `GET`    | `/transactions/{groupId}/attachments` | |
+| `GET`    | `/transactions/{groupId}/piggy-bank-events` | Piggy-bank effects this tx caused |
+| `GET`    | `/transaction-journals/{journalId}` | Single journal (split) lookup |
+| `DELETE` | `/transaction-journals/{journalId}` | Delete one split inside a group |
+| `GET`    | `/transaction-journals/{journalId}/links` | Cross-references to other transactions |
+| `POST`   | `/data/bulk/transactions` | Bulk patch — set category/tags/budget on many txs |
+
+`type` filter values: `all`, `withdrawal`, `deposit`, `transfer`, `opening_balance`, `reconciliation`, `special` (the catch-all for the previous three).
+
+### Store body
+
+```json
+{
+  "error_if_duplicate_hash": true,
+  "apply_rules": true,
+  "fire_webhooks": true,
+  "group_title": null,
+  "transactions": [
+    {
+      "type": "withdrawal",
+      "date": "2026-05-17",
+      "amount": "12.34",
+      "description": "Coffee",
+      "source_id": 1,
+      "destination_name": "Cafe Pina",
+      "category_name": "Food & Drink",
+      "tags": ["coffee", "morning"],
+      "notes": "Espresso doppio",
+      "external_id": "revolut:tx_abc123",
+      "currency_code": "EUR",
+      "foreign_amount": null,
+      "foreign_currency_code": null,
+      "budget_name": "Eating out",
+      "bill_id": null,
+      "reconciled": false
+    }
+  ]
+}
+```
+
+Rules of thumb:
+- `transactions[]` length > 1 ⇒ this is a **split**; `group_title` becomes the parent description.
+- For a withdrawal: `source_id` (or `source_name`) is the asset account; `destination_id`/`_name` is the expense account (auto-created if name not found).
+- For a deposit: source = revenue account, destination = asset.
+- For a transfer: both source and destination are asset accounts.
+- For foreign currency: set `currency_code` to the *foreign* currency of the transaction, and `foreign_amount`+`foreign_currency_code` to the asset account's currency conversion. Example: EUR account paying in USD ⇒ `amount:"100.00", currency_code:"USD", foreign_amount:"92.40", foreign_currency_code:"EUR"`.
+- `external_id` is your idempotency key for re-import scenarios. With `error_if_duplicate_hash: true`, replays get `422 a115` instead of duplicates.
+- All amounts are positive strings. The sign is implied by `type`.
+
+### Update
+
+`PUT /transactions/{groupId}` accepts the same envelope; provide only the journals you want to change. Each journal's `transaction_journal_id` identifies it; omit it to create a new split, include without other fields to delete.
+
+### Bulk patch
+
+```bash
+POST /data/bulk/transactions
+{
+  "query": {"where": {"category_id": 5}},
+  "update": {"category_id": 12}
+}
+```
+
+The `query` is a Firefly search expression (same syntax as `/search/transactions`) OR a raw filter object. Bulk patch only supports updates of category, budget, tags. For anything else, fall back to per-tx `PUT`.
+
+## 7. Categories, tags, budgets, bills, piggy banks
+
+All five follow the same CRUD pattern: `GET /index`, `POST /index`, `GET/PUT/DELETE /{id}`.
+
+### Categories — `/categories`
+Plain labels. Stores per-period sums when queried with `?start=..&end=..`.
+- `GET /categories/{id}/transactions`
+- `GET /categories/{id}/attachments`
+
+### Tags — `/tags`
+Tags can have a date + lat/lng + zoom-level (geo-tag). Path supports `tagOrId` so you can `GET /tags/groceries` or `/tags/42`.
+
+### Budgets — `/budgets`
+Budgets are buckets; `available-budgets` are the monthly envelopes; `budget-limits` are the period caps.
+- `GET  /budgets` / `POST /budgets`
+- `GET  /budgets/{id}/transactions`
+- `GET  /budgets/{id}/limits` → list budget limits
+- `POST /budgets/{id}/limits` → set a limit `{start, end, amount, currency_code}`
+- `PUT/DELETE /budget-limits/{id}` for the limit objects themselves
+- `GET  /available-budgets` → the "money I want to spend this month" envelopes
+
+### Bills (subscriptions) — `/bills` and identical alias `/subscriptions`
+Recurring expectations of a payment (rent, Netflix). Firefly matches incoming transactions to bills via rule-like criteria.
+```json
+{
+  "name": "Spotify",
+  "amount_min": "9.99", "amount_max": "9.99",
+  "date": "2026-01-15",
+  "repeat_freq": "monthly",
+  "skip": 0,
+  "active": true,
+  "currency_code": "EUR"
+}
+```
+- `GET /bills/{id}/transactions` — matched txs
+- `GET /bills/{id}/rules` — rules that fire bill matching
+- `GET /bills/{id}/attachments`
+
+### Piggy banks — `/piggy-banks`
+Savings goals tied to one or more asset accounts.
+```json
+{
+  "name": "Holiday",
+  "accounts": [{"id": 1, "current_amount": "0"}],
+  "target_amount": "1500.00",
+  "start_date": "2026-01-01",
+  "target_date": "2026-12-31",
+  "object_group_title": "Travel"
+}
+```
+- `GET /piggy-banks/{id}/events` — every deposit/withdrawal
+- `GET /piggy-banks/{id}/accounts`, `/piggy-banks/{id}/attachments`
+
+## 8. Recurrences — `/recurrences`
+
+Templates that the cron expands into real transactions.
+- `GET /recurrences` — list
+- `POST /recurrences` — create
+- `GET/PUT/DELETE /recurrences/{id}`
+- `GET /recurrences/{id}/transactions` — instances created so far
+- `POST /recurrences/{id}/trigger` — force one occurrence to fire now (idempotent: respects the recurrence's "next date")
+
+Body sketch:
+```json
+{
+  "title": "Rent",
+  "first_date": "2026-06-01",
+  "repetitions": [{"type": "monthly", "moment": "1", "skip": 0, "weekend": 1}],
+  "transactions": [{
+    "description": "Rent payment",
+    "amount": "850",
+    "type": "withdrawal",
+    "currency_code": "EUR",
+    "source_id": 1, "destination_name": "Landlord"
+  }],
+  "apply_rules": true,
+  "active": true,
+  "notes": ""
+}
+```
+
+`weekend` values: `1` do nothing, `2` skip, `3` advance to Friday, `4` postpone to Monday.
+
+## 9. Rules and rule groups
+
+### Rule groups — `/rule-groups`
+Containers for rules with an `order`.
+- `GET /rule-groups/{id}/rules` — list rules inside
+- `GET /rule-groups/{id}/test?start=..&end=..&accounts[]=1` — dry-run what would match
+- `POST /rule-groups/{id}/trigger?start=..&end=..&accounts[]=1` — actually fire all rules on the date range
+
+### Rules — `/rules`
+- `GET /rules/validate-expression?expression=...` — sanity-check a search expression before saving
+- `GET /rules/{id}/test?start=..&end=..` — dry-run
+- `POST /rules/{id}/trigger?start=..&end=..` — fire one rule
+
+Rule body shape:
+```json
+{
+  "title": "Tag groceries",
+  "rule_group_id": 1,
+  "trigger": "store-journal",
+  "strict": true,
+  "stop_processing": false,
+  "active": true,
+  "triggers": [
+    {"type": "destination_account_starts", "value": "Supermarket"}
+  ],
+  "actions": [
+    {"type": "add_tag", "value": "groceries", "order": 1},
+    {"type": "set_category", "value": "Food", "order": 2}
+  ]
+}
+```
+Common trigger types: `description_is`, `description_contains`, `description_starts`, `description_ends`, `amount_is`, `amount_more`, `amount_less`, `source_account_is`, `destination_account_is`, `transaction_type`, `has_any_tag`, `notes_contains`, `category_is`, `budget_is`, `currency_is`.
+Common action types: `set_category`, `set_budget`, `add_tag`, `remove_tag`, `set_notes`, `append_notes`, `prepend_notes`, `set_description`, `link_to_bill`, `convert_withdrawal`, `convert_deposit`, `convert_transfer`, `delete_transaction`.
+
+`trigger` (the rule-level field, not the array) values: `store-journal` (on creation), `update-journal` (on edit), `manual` (only when triggered explicitly).
+
+### CLI alternative
+
+For massive backfills use `php artisan firefly-iii:apply-rules` (see `references/cli.md`) — much faster than the API for thousands of transactions.
+
+## 10. Webhooks — `/webhooks`
+
+Outbound webhooks Firefly fires after specific events.
+- `GET/POST /webhooks`
+- `GET/PUT/DELETE /webhooks/{id}`
+- `POST /webhooks/{id}/submit` — manually flush pending deliveries
+- `POST /webhooks/{id}/trigger-transaction/{groupId}` — fire this webhook against an existing tx
+- `GET /webhooks/{id}/messages` → list of generated payloads
+- `GET /webhooks/{id}/messages/{msgId}` → one payload + state
+- `DELETE /webhooks/{id}/messages/{msgId}` → clear
+- `GET /webhooks/{id}/messages/{msgId}/attempts` → per-attempt delivery log
+
+Body:
+```json
+{
+  "title": "Notify HA",
+  "active": true,
+  "trigger": "STORE_TRANSACTION",
+  "response": "TRANSACTIONS",
+  "delivery": "JSON",
+  "url": "https://hass.home/api/webhook/firefly_new_tx"
+}
+```
+`trigger` values: `STORE_TRANSACTION`, `UPDATE_TRANSACTION`, `DESTROY_TRANSACTION`.
+`response` values: `TRANSACTIONS`, `ACCOUNTS`, `NONE`.
+
+The `webhook_secret` is autogenerated and exposed on the show endpoint — receivers can verify the `X-Firefly-Signature` header.
+
+## 11. Attachments, links, object-groups, preferences, configuration
+
+### Attachments — `/attachments`
+Two-step upload:
+1. `POST /attachments` with `{filename, attachable_type:"TransactionJournal", attachable_id:N, title, notes}` returns an attachment ID.
+2. `POST /attachments/{id}/upload` with raw body bytes (`Content-Type: application/octet-stream`) uploads the file.
+3. `GET /attachments/{id}/download` streams the file back.
+
+### Transaction links — `/transaction-links` and `/link-types`
+Link two transaction journals (refund, related, etc.). Link types are user-defined:
+- `GET/POST /link-types` (POST is owner-only in single-user setups; default types come pre-installed)
+- `GET/POST /transaction-links` `{link_type_id, inward_id, outward_id, notes}`
+
+### Object groups — `/object-groups`
+Tagging mechanism for piggy banks/bills (the "Travel" / "Recurring" groupings in the UI).
+- `GET /object-groups` / `GET/PUT/DELETE /object-groups/{id}`
+
+### Preferences — `/preferences`
+Per-user settings stored as serialized JSON.
+- `GET /preferences` — list all
+- `GET /preferences/{name}` — read one (e.g. `currencyPreference`, `frontPageAccounts`, `viewRange`)
+- `PUT /preferences/{name}` — `{data: <json-encoded value>}`
+- `POST /preferences` — create new
+
+### Configuration — `/configuration`
+System-level config — admin only.
+- `GET /configuration` — list (e.g. `permission_update_check`, `last_update_check`, `single_user_mode`, `is_demo_site`)
+- `GET /configuration/{key}`
+- `PUT /configuration/{key}` — `{value: ...}` (only for "dynamic" keys, i.e. not the immutable ones)
+
+## 12. Currencies and exchange rates
+
+### Currencies — `/currencies`
+- `GET /currencies` — list (each has `enabled`, `default`)
+- `POST /currencies` `{code, name, symbol, decimal_places, enabled}`
+- `GET /currencies/{code}`, `GET /currencies/primary` (= default)
+- `POST /currencies/{code}/enable` / `/disable`
+- `POST /currencies/{code}/primary` — set as primary (formerly "default")
+- `PUT /currencies/{code}` — rename/relabel
+- `DELETE /currencies/{code}` — only if no records reference it
+- Many `/currencies/{code}/<resource>` listing endpoints: `accounts`, `bills`, `budget-limits`, `available-budgets`, `cer`, `recurrences`, `rules`, `transactions`
+
+### Exchange rates — `/exchange-rates`
+- `GET /exchange-rates?from=EUR&to=USD&date=...&limit=...`
+- `GET /exchange-rates/{from}/{to}` — list all dated rates
+- `GET /exchange-rates/{from}/{to}/{YYYY-MM-DD}` — one rate
+- `GET /exchange-rates/{id}` — by internal id
+- `POST /exchange-rates` `{from_currency_code, to_currency_code, date, rate}`
+- `POST /exchange-rates/by-date/{date}` — batch by date
+- `POST /exchange-rates/by-currencies/{from}/{to}` — batch for a pair
+- `PUT /exchange-rates/{id}` / `PUT /exchange-rates/{from}/{to}/{date}` — update
+- `DELETE /exchange-rates/{from}/{to}` — delete all for a pair
+- `DELETE /exchange-rates/{from}/{to}/{date}` — delete one
+
+## 13. Charts, insight, reports
+
+### Charts — `/chart/*`
+Pre-aggregated series for dashboards.
+- `GET /chart/balance/balance?start=..&end=..&accounts[]=1&accounts[]=2` — line series
+- `GET /chart/account/overview?start=..&end=..&accounts[]=...` — per-account net change
+- `GET /chart/budget/overview?start=..&end=..` — budget consumption
+- `GET /chart/category/overview?start=..&end=..` — top categories
+
+### Insight — `/insight/*`
+Breakdowns by dimension. Three top groups: `expense`, `income`, `transfer`.
+
+For **expense** (`/insight/expense/...`):
+- `/expense` — per expense-account spend
+- `/asset` — per asset-account net outflow
+- `/total?start=..&end=..` — total in period
+- `/bill` / `/no-bill` — spending tied to bills vs. ad-hoc
+- `/budget` / `/no-budget` — budgeted vs. unbudgeted
+- `/category` / `/no-category`
+- `/tag` / `/no-tag`
+
+For **income** (`/insight/income/...`): `/revenue`, `/asset`, `/total`, `/category`, `/no-category`, `/tag`, `/no-tag`.
+
+For **transfer** (`/insight/transfer/...`): `/asset`, `/category`, `/no-category`, `/tag`, `/no-tag`, `/total`.
+
+All take `start`, `end`; many take filter arrays (`accounts[]`, `tags[]`, `budgets[]`, etc.).
+
+### Reports
+No dedicated `/reports` endpoint — build reports by combining `/summary/basic`, `/insight/*`, and `/chart/*`. The browser UI does exactly this.
+
+## 14. Data export, destroy, purge, bulk update
+
+### Export — `/data/export/*` (read-only, returns CSV/JSON)
+- `/data/export/accounts`
+- `/data/export/transactions?start=..&end=..&accounts[]=...`
+- `/data/export/budgets`, `/data/export/bills` (alias `/subscriptions`), `/data/export/categories`, `/data/export/tags`
+- `/data/export/piggy-banks`, `/data/export/recurring`, `/data/export/rules`
+
+Each takes `?type=csv|json` (default csv). Headers: `Content-Disposition: attachment`. Pipe to a file:
+```bash
+ff-api.sh GET '/api/v1/data/export/transactions?start=2026-01-01&end=2026-12-31&type=csv' > tx.csv
+```
+
+For full system export use the **CLI** `firefly-iii:export-data` — it can dump everything in one go.
+
+### Destroy — `DELETE /data/destroy?objects=<type>`
+Wholesale wipe by category. **Destructive** — confirm with the user first.
+`objects` values: `budgets`, `bills`, `piggy_banks`, `rules`, `recurring`, `categories`, `tags`, `object_groups`, `not_assets_liabilities`, `accounts` (asset accounts cascade — wipes everything), `asset_accounts`, `expense_accounts`, `revenue_accounts`, `liabilities`, `transactions`, `withdrawals`, `deposits`, `transfers`.
+
+### Purge — `DELETE /data/purge`
+Permanently removes anything currently soft-deleted (transactions, accounts, etc.). Run after a `correct-database` if you want to free DB space.
+
+### Bulk update — `POST /data/bulk/transactions`
+See [transactions](#6-transactions).
+
+## 15. Users, user-groups, batch, system
+
+### Users — `/users` (admin only)
+- `GET /users` / `POST /users`
+- `GET/PUT/DELETE /users/{id}`
+
+`POST /users` requires `{email, role, password (optional)}`. Roles: `owner`, `demo`, `null`. Multi-user is feature-flagged via the user-groups system below.
+
+### User groups — `/user-groups`
+- `GET /user-groups` / `GET /user-groups/{id}` / `PUT /user-groups/{id}`
+- Group memberships are managed through the UI only at present.
+
+### Batch — `/batch`
+- `POST /batch/finish` — bookkeeping endpoint used by the importer to mark a batch complete.
+
+### System — cron + about
+- `GET /cron/{cliToken}` — fires the cron over HTTP (matches the `STATIC_CRON_TOKEN` env). Not bearer-authed. Used by the scheduler container's wget cron.
+- `GET /about` / `/about/user` — see [section 4](#4-about-summary-search-autocomplete).

--- a/.claude/skills/firefly/references/cli.md
+++ b/.claude/skills/firefly/references/cli.md
@@ -1,0 +1,308 @@
+# Firefly III artisan CLI reference
+
+Operational reference for the Laravel/artisan commands that ship inside the `fireflyiii/core` image (currently 6.6.2 on this stack). Every command runs as:
+
+```bash
+docker exec <firefly-app-container> php artisan <command> [args]
+```
+
+Use `scripts/ff-artisan.sh` from this skill — it resolves the container by Swarm label and SSHes for you. From the Pi directly: `docker exec $(docker ps -qf 'label=com.docker.swarm.service.name=firefly_app' | head -1) php artisan ...`.
+
+> Official user-facing docs: <https://docs.firefly-iii.org/references/firefly-iii/cli/>. That page only covers `cron`, `apply-rules`, `export-data`. Everything else below is sourced from the command classes in `app/Console/Commands/*` on the deployed version's tag.
+
+## Command surface
+
+The signatures fall into five buckets — `firefly-iii:*` (user-facing), `correction:*` / `integrity:*` (db hygiene), `system:*` (recovery), and `firefly-iii:upgrade-database` (one-shot migrations). All commands print to stdout — capture exit code for scripting.
+
+`php artisan` with no argument lists every command. This includes Laravel built-ins, upgrade commands, and integrity tooling.
+
+---
+
+## 1. Tools — daily operations
+
+### `firefly-iii:cron`
+Fires every scheduled job: process recurring transactions, run auto-budgets, refresh exchange rates, send bill reminders, recompute running balances. **Idempotent within the day.**
+
+This is what the `firefly-scheduler` Alpine container runs nightly:
+```bash
+docker exec <firefly-app> php artisan firefly-iii:cron
+```
+On this stack it's also reachable over HTTP at `GET /api/v1/cron/{STATIC_CRON_TOKEN}` (unauthenticated, token-gated). The scheduler uses `docker exec` so this HTTP path is a backup.
+
+**Flags:**
+- `--force` — ignore the "already ran today" guard.
+- `--date=YYYY-MM-DD` — pretend the run is happening on that date (useful for back-filling recurring tx the cron missed).
+
+### `firefly-iii:apply-rules`
+Bulk-replays rules against historical transactions. The API equivalent is per-rule and slower; use this for large back-fills.
+
+```bash
+php artisan firefly-iii:apply-rules \
+  --user=1 \
+  --token=<access_token> \
+  --accounts=1,2,3 \
+  --rule_groups=4 \
+  --start_date=2026-01-01 \
+  --end_date=2026-05-17
+```
+
+Key flags:
+- `--user=USER` (default `1`) — single-user setup is always `1`.
+- `--token=TOKEN` — Personal Access Token from Profile → OAuth.
+- `--accounts=...` — comma-separated asset/liability IDs (omit = all).
+- `--rule_groups=...` — comma-separated group IDs.
+- `--rules=...` — comma-separated rule IDs. **Overrides** `rule_groups`.
+- `--all_rules` — apply every rule. Overrides both.
+- `--start_date=`/`--end_date=` `YYYY-MM-DD` (inclusive). Omit = full history.
+
+Watches: a rule with `delete_transaction` action will silently nuke matched txs. `GET /rules/{id}/test` first.
+
+### `firefly-iii:check-for-updates [--force]`
+Pings the update server to check for new Firefly releases. Result is cached in DB (`last_update_check`). On this stack we update via Shepherd watching the `fireflyiii/core:latest` image, so this command's main use is dismissing the "update available" banner after Shepherd pulls.
+
+### `firefly-iii:verify-database-connection`
+Smoke test — connects to MariaDB using `.env` credentials, returns nonzero on failure. Useful before running a `correct-database` to be sure the DB is reachable.
+
+### `firefly-iii:send-test-email`
+Sends a mail through whatever `MAIL_*` env vars are configured. Current stack has `MAIL_MAILER=log` (no real mailer), so this just writes to the laravel log inside the container — confirm with `docker service logs -f firefly_app`.
+
+---
+
+## 2. Export
+
+### `firefly-iii:export-data`
+Dump user data to CSV/JSON files. The container writes to whatever `--export_directory` you pass — default `./` (i.e. `/var/www/html`). Most useful target on this stack: `/var/www/html/storage/upload/` which is mounted on the `firefly_upload` volume and visible to both `firefly_app` and `firefly_importer`.
+
+```bash
+ff-artisan.sh firefly-iii:export-data \
+  --user=1 \
+  --token=<access_token> \
+  --export_directory=/var/www/html/storage/upload \
+  --start=2026-01-01 \
+  --end=2026-12-31 \
+  --export-transactions \
+  --export-accounts \
+  --export-budgets \
+  --export-categories \
+  --export-tags \
+  --export-recurring \
+  --export-rules \
+  --export-subscriptions \
+  --export-piggies
+```
+
+Combine flags freely. `--force` overwrites any existing file with the same name. Files land as `<date>-transactions.csv`, `<date>-accounts.csv`, etc.
+
+> The `--token` here must be a **Personal Access Token**, not the cron token. Read it from the `firefly_access_token` secret on the scheduler.
+
+After export, retrieve from your machine:
+```bash
+scp giorgiocaizzi@pi.local:/var/lib/docker/volumes/firefly_firefly_upload/_data/*.csv ./
+```
+
+---
+
+## 3. System — recovery and version
+
+### `system:create-first-user <email>`
+Creates the bootstrap admin and prints the generated password on stdout. Intended for fresh-installs and tests only — running on an existing instance creates an additional user.
+
+### `firefly-iii:output-version`
+Prints the version string (e.g. `6.6.2`). Cheaper than hitting `/api/v1/about`.
+
+### `firefly-iii:set-latest-version [--james-is-cool]`
+Stamps the DB with the current code version after a manual upgrade. The flag is required (it is, in fact, the actual flag name) — it's a sanity check to stop you running this by accident. Run after upgrading the image if Firefly throws a "please upgrade DB" error you've already resolved.
+
+### `firefly-iii:laravel-passport-keys`
+Wrapper around `passport:keys` that returns success even if the keys already exist. Use after restoring `storage/oauth-*.key` from a backup to regenerate any missing pair.
+
+### `firefly-iii:scan-attachments`
+Re-scans every attachment in storage, recomputes MD5 and mime, updates the DB. Run after restoring the `firefly_upload` volume from backup or after moving attachments between hosts.
+
+### `firefly-iii:refresh-running-balance [-F|--force]`
+Recomputes every account's running balance from the journal history. Mandatory after any direct SQL on `transactions` or `transaction_journals`. **Slow** on large histories — use `--force` if a previous run was interrupted and the cache is stuck.
+
+### `firefly-iii:reset-error-mail-limit`
+Resets the throttle on error emails (Firefly will only mail the same error once per N minutes). Run after fixing a noisy bug so the next occurrence is reported.
+
+### `firefly-iii:verify-security-alerts`
+Cross-checks the app version against the Firefly III security alert feed. The `firefly-iii:cron` job runs this implicitly; invoke directly to test connectivity.
+
+### `system:create-database`
+Bootstraps the schema on a fresh DB. The image runs this on first boot — only useful if you've created a new database manually.
+
+### `system:forces-migrations` (`firefly-iii:force-migrations`)
+Forces `migrate` to re-apply, ignoring the `migrations` table state. **Destructive.** Only used by support when an upgrade left the DB half-migrated.
+
+### `system:forces-decimal-size`
+Re-aligns DB columns to the decimal precision the code expects. Safe to re-run.
+
+### `system:outputs-instructions`
+Prints the post-install instructions (URL, register first user, OAuth, etc.) that you see at the end of `docker logs firefly-app` after boot.
+
+---
+
+## 4. Correction — database hygiene
+
+These commands fix specific data anomalies. They are safe to run repeatedly; each verifies before mutating. Run them through `firefly-iii:correct-database` (which dispatches the full suite) rather than individually, except when you know exactly which fix you want.
+
+### `firefly-iii:correct-database`
+Runs *every* `correction:*` and most `integrity:*` commands in the right order. Idempotent. This is the "fix everything" hammer — invoke after:
+- A restore from backup
+- A manual SQL repair on `transaction_groups` / `transaction_journals` / `transactions` (see `references/db.md`)
+- An upgrade that warns about integrity issues
+
+After it finishes, clear the cache and refresh balances:
+```bash
+ff-artisan.sh cache:clear
+ff-artisan.sh firefly-iii:correct-database
+ff-artisan.sh firefly-iii:refresh-running-balance
+```
+
+### Individual `correction:*` commands
+
+| Command | Fixes |
+|---|---|
+| `correction:access-tokens` | Generates per-user CLI access tokens missing from `preferences` |
+| `correction:restore-oauth-keys` | Regenerates `storage/oauth-{public,private}.key` if lost (e.g. after volume reset) — fixes `401 Unauthenticated` for every API call |
+| `firefly-iii:clears-empty-foreign-amounts` | Clears `foreign_amount`/`foreign_currency_id` left as zero/null inconsistently |
+| `firefly-iii:converts-dates-to-utc` | One-off; converts dates stored without TZ to UTC. Run by upgrade only |
+| `firefly-iii:corrects-account-order` | Re-numbers `order` column on accounts |
+| `firefly-iii:corrects-account-types` | Fixes mis-typed account rows |
+| `firefly-iii:corrects-amounts` | Recomputes `amount` on `transactions` from `amount_with_currency` |
+| `firefly-iii:corrects-currencies` | Aligns transaction currency with the account currency |
+| `firefly-iii:corrects-frontpage-accounts` | Removes deleted accounts from the dashboard preference |
+| `firefly-iii:corrects-group-accounts` | Cleans up multi-user group memberships |
+| `firefly-iii:corrects-group-information` | Recomputes `group_title` after splits change |
+| `firefly-iii:corrects-ibans` | Strips spaces and uppercases IBAN columns |
+| `firefly-iii:corrects-inverted-budget-limits` | Fixes negative budget limits inserted incorrectly |
+| `firefly-iii:corrects-long-descriptions` | Truncates over-long descriptions to the column limit |
+| `firefly-iii:corrects-meta-data-fields` | Removes orphaned `journal_meta` rows |
+| `firefly-iii:corrects-opening-balance-currencies` | Aligns OB rows with the account currency |
+| `firefly-iii:corrects-piggy-banks` | Recomputes piggy-bank totals from `piggy_bank_events` |
+| `firefly-iii:corrects-preferences` | Removes preferences referencing deleted entities |
+| `firefly-iii:corrects-primary-currency-amounts` | Recomputes the "primary currency" mirror columns |
+| `firefly-iii:corrects-recurring-transactions` | Repairs broken recurrence definitions |
+| `firefly-iii:corrects-timezone-information` | Fixes TZ on journal dates |
+| `firefly-iii:corrects-transaction-types` | Reassigns `transaction_type_id` based on source/destination types |
+| `firefly-iii:corrects-transfer-budgets` | Removes budgets attached to transfers (illegal combo) |
+| `firefly-iii:corrects-uneven-amount` | Fixes journals where the two transaction rows don't sum to zero |
+| `firefly-iii:creates-group-memberships` | Backfills `user_group` rows from `users` |
+| `firefly-iii:creates-link-types` | Ensures the default 4 link types exist |
+| `firefly-iii:removes-bills` | Removes bill rows that have no name/dates |
+| `firefly-iii:removes-empty-groups` | Drops `transaction_groups` with zero journals |
+| `firefly-iii:removes-empty-journals` | Drops `transaction_journals` with fewer than 2 `transactions` rows |
+| `firefly-iii:removes-links-to-deleted-objects` | Cleans `journal_links` pointing at soft-deleted journals |
+| `firefly-iii:removes-orphaned-transactions` | Drops `transactions` whose parent journal vanished |
+| `firefly-iii:removes-zero-amount` | Drops `transactions` with `amount=0` (the API rejects these on store, but legacy data may have them) |
+| `firefly-iii:triggers-credit-calculation` | Recomputes liability "credit" balances |
+| `firefly-iii:rollback-single-migration` | Reverses one migration. **Last resort** — used to recover from a failed upgrade |
+
+---
+
+## 5. Integrity — reports (read-only)
+
+Every `integrity:*` and the `firefly-iii:report-*` commands are non-destructive. They print findings and exit. Run before a `correct-database` to see what will change.
+
+| Command | Reports |
+|---|---|
+| `firefly-iii:report-integrity` | Top-level overview — calls the others |
+| `firefly-iii:reports-empty-objects` | Budgets/categories/bills/tags with no transactions |
+| `firefly-iii:reports-sums` | Per-user money sums (sanity check against a backup) |
+| `integrity:validates-environment-variables` | Warns about deprecated / typo env vars (e.g. `APP_KEY` length, missing `_FILE` paths) |
+| `integrity:validates-file-permissions` | Checks `/var/www/html/storage` is writable |
+
+---
+
+## 6. Upgrade — version migrations
+
+These commands run automatically when the container starts on a new version. You only invoke them manually if `firefly-iii:upgrade-database` (the umbrella) fails partway through and you need to re-run a specific step.
+
+### `firefly-iii:upgrade-database`
+Runs every `firefly-iii:upgrades-*` step in order. Replaces `migrate:fresh` for app-level schema migrations (which still run via Laravel `migrate`). Idempotent.
+
+Individual steps (do not normally run by hand):
+- `firefly-iii:adds-transaction-identifiers` — backfills the `external_id` column
+- `firefly-iii:removes-database-decryption` — strips legacy encrypted columns
+- `firefly-iii:repairs-account-balances`, `firefly-iii:repairs-postgres-sequences`
+- `firefly-iii:upgrades-account-currencies`, `firefly-iii:upgrades-account-meta-data`
+- `firefly-iii:upgrades-attachments`
+- `firefly-iii:upgrades-bills-to-rules`
+- `firefly-iii:upgrades-budget-limits`, `firefly-iii:upgrades-budget-limit-periods`
+- `firefly-iii:upgrades-credit-card-liabilities`
+- `firefly-iii:upgrades-currency-preferences`, `firefly-iii:upgrades-various-currency-information`
+- `firefly-iii:upgrades-database` (top-level entry, but also callable)
+- `firefly-iii:upgrades-journal-meta-data`, `firefly-iii:upgrades-journal-notes`
+- `firefly-iii:upgrades-liabilities`, `firefly-iii:upgrades-liabilities-eight`
+- `firefly-iii:upgrades-multi-piggy-banks`
+- `firefly-iii:upgrades-primary-currency-amounts`
+- `firefly-iii:upgrades-recurrence-meta-data`
+- `firefly-iii:upgrades-rule-actions`
+- `firefly-iii:upgrades-tag-locations`
+- `firefly-iii:upgrades-to-groups`
+- `firefly-iii:upgrades-transfer-currencies`
+- `firefly-iii:upgrades-webhooks`
+
+---
+
+## 7. Laravel built-ins worth knowing
+
+These are not `firefly-iii:*` commands but ship with Laravel. Run them inside the app container.
+
+| Command | Use |
+|---|---|
+| `cache:clear` | After config or DB change |
+| `config:clear` / `config:cache` | If you edit `.env` and the new value isn't read |
+| `route:clear` | After upgrades that touched routes |
+| `view:clear` | After UI upgrades |
+| `queue:work --once` | Run one queued job (Firefly uses sync queue by default, so rarely needed) |
+| `passport:keys --force` | Forcibly regenerate OAuth signing keys — invalidates existing tokens |
+| `passport:client --personal` | Create a new Personal Access *Client* (one-time, after passport keys reset) |
+| `passport:install` | Bootstrap Passport on a fresh install |
+| `migrate` | Apply schema migrations (idempotent) |
+| `tinker` | REPL on the live app (read `App\Models\...` to inspect) |
+
+---
+
+## 8. Typical command sequences
+
+**Nightly cron (what the scheduler runs):**
+```bash
+ff-artisan.sh firefly-iii:cron
+```
+
+**Recover from a database restore:**
+```bash
+ff-artisan.sh cache:clear
+ff-artisan.sh firefly-iii:report-integrity     # see what's broken
+ff-artisan.sh firefly-iii:correct-database     # fix it
+ff-artisan.sh firefly-iii:refresh-running-balance --force
+```
+
+**Recover from a lost `storage/oauth-*.key`:**
+```bash
+ff-artisan.sh correction:restore-oauth-keys
+ff-artisan.sh firefly-iii:laravel-passport-keys
+ff-artisan.sh cache:clear
+```
+All existing Personal Access Tokens **stay valid** — they're signed with the same restored key pair.
+
+**Full export of every user object:**
+```bash
+ff-artisan.sh firefly-iii:export-data \
+  --token=$(ssh giorgiocaizzi@pi.local 'docker exec $(docker ps -qf label=com.docker.swarm.service.name=firefly_scheduler | head -1) cat /run/secrets/firefly_access_token') \
+  --export_directory=/var/www/html/storage/upload \
+  --export-transactions --export-accounts --export-budgets \
+  --export-categories --export-tags --export-recurring \
+  --export-rules --export-subscriptions --export-piggies \
+  --force
+```
+
+**Bulk-apply all rules to last quarter:**
+```bash
+ff-artisan.sh firefly-iii:apply-rules \
+  --token=<...> \
+  --all_rules \
+  --start_date=2026-02-01 \
+  --end_date=2026-04-30
+```

--- a/.claude/skills/firefly/references/db.md
+++ b/.claude/skills/firefly/references/db.md
@@ -1,0 +1,207 @@
+# Firefly III database reference
+
+Direct database operations on the MariaDB instance `firefly_db`. Read this **only** when the API and CLI cannot recover the situation. Every SQL mutation must be followed by `firefly-iii:correct-database`, `cache:clear`, and `firefly-iii:refresh-running-balance` — otherwise Firefly's in-memory caches and computed balances diverge from the row state.
+
+## Connecting
+
+The DB password lives in the `firefly_db_password` swarm secret, mounted in both the app and db containers. Pull it from the app:
+
+```bash
+ssh giorgiocaizzi@pi.local '
+  APP=$(docker ps --filter "label=com.docker.swarm.service.name=firefly_app" --format "{{.Names}}" | head -1)
+  DB=$(docker ps --filter "label=com.docker.swarm.service.name=firefly_db" --format "{{.Names}}" | head -1)
+  DB_PASS=$(docker exec "$APP" cat /run/secrets/db_password)
+  docker exec -it "$DB" mariadb -u firefly -p"$DB_PASS" firefly
+'
+```
+
+For a one-shot query, swap `-it` for `-e "SELECT ...;"`.
+
+## Schema cheat-sheet
+
+Firefly groups every change to money as a three-level structure:
+
+```
+transaction_groups        (1)  ── parent, holds title for splits
+  └── transaction_journals (1+) ── one per split; holds description, date, type
+        └── transactions   (2+) ── debit + credit rows
+              └── account_id, amount, currency, foreign_amount, ...
+```
+
+**Transaction types** (`transaction_journals.transaction_type_id` → `transaction_types.id`):
+
+| id | type |
+|---|---|
+| 1 | Deposit |
+| 2 | Invalid |
+| 3 | Liability credit |
+| 4 | Opening balance |
+| 5 | Reconciliation |
+| 6 | Transfer |
+| 7 | Withdrawal |
+
+**Account types** (`accounts.account_type_id` → `account_types.id`):
+
+| id | type |
+|---|---|
+| 1 | Default account |
+| 2 | Cash account |
+| 3 | Asset account |
+| 4 | Expense account |
+| 5 | Revenue account |
+| 6 | Initial balance account |
+| 7 | Beneficiary account |
+| 8 | Import account |
+| 9 | Loan |
+| 10 | Reconciliation account |
+| 11 | Credit card |
+| 12 | Debt |
+| 13 | Mortgage |
+| 14 | Liability |
+| 15 | Liability credit account |
+
+**Other essential tables:**
+
+| Table | Holds |
+|---|---|
+| `users` | Single row in single-user mode (`id=1`) |
+| `accounts` | All account types |
+| `account_meta` | KV side-table for account extras (`account_role`, `currency_id`, `account_number`, `BIC`, `IBAN_holder`, …) |
+| `transaction_currencies` | `EUR`, `USD`, … (used by `currency_id`) |
+| `categories`, `budgets`, `budget_limits`, `available_budgets` | |
+| `tags`, `tag_transaction_journal` (M2M) | |
+| `bills` | Subscriptions |
+| `piggy_banks`, `piggy_bank_events`, `piggy_bank_repetitions`, `account_piggy_bank` | Goals + per-account split |
+| `recurrences`, `recurrences_meta`, `recurrences_repetitions`, `recurrences_transactions` | Recurring tx |
+| `rule_groups`, `rules`, `rule_triggers`, `rule_actions` | |
+| `journal_links`, `link_types` | Cross-references between journals |
+| `attachments` | DB row + file in `storage/upload` |
+| `journal_meta` | KV side-table for journal extras (`external_id`, `original-source`, geo, etc.) |
+| `webhooks`, `webhook_messages`, `webhook_attempts` | |
+| `oauth_*` | Passport tables (clients, tokens, refresh tokens) |
+| `preferences` | Per-user serialised JSON settings |
+| `configuration` | System-level KV |
+| `failed_jobs`, `jobs` | Laravel queue (sync queue by default; usually empty) |
+| `migrations` | Laravel migration state |
+
+## Soft-delete semantics — the critical invariant
+
+`transaction_groups`, `transaction_journals`, `transactions`, `accounts`, and most user-owned tables carry a `deleted_at TIMESTAMP NULL`. `NULL` = active; non-null = soft-deleted.
+
+**Firefly enforces parent-child consistency.** On boot and via `firefly-iii:correct-database`, if a parent is soft-deleted, the cascade re-deletes the children — *even if you restored them*. If you restore in the wrong order, your fix is silently reverted.
+
+**Always restore top-down: groups → journals → transactions.** Always delete bottom-up if you must.
+
+## Rollback pattern (restore a set of soft-deleted transactions)
+
+Use a deterministic match key — `description LIKE`, an `external_id` in `journal_meta`, or an explicit list of `transaction_group_id`s. Below uses a description pattern; substitute your own.
+
+```sql
+-- 1. Restore parent groups (idempotent — only un-deletes already-deleted rows)
+UPDATE transaction_groups
+SET    deleted_at = NULL, updated_at = NOW()
+WHERE  deleted_at IS NOT NULL
+AND    EXISTS (
+         SELECT 1 FROM transaction_journals tj
+         WHERE  tj.transaction_group_id = transaction_groups.id
+         AND    tj.description LIKE '%<pattern>%'
+       );
+
+-- 2. Restore the journals
+UPDATE transaction_journals
+SET    deleted_at = NULL, updated_at = NOW()
+WHERE  deleted_at IS NOT NULL
+AND    description LIKE '%<pattern>%';
+
+-- 3. Restore the underlying transaction rows
+UPDATE transactions t
+SET    t.deleted_at = NULL, t.updated_at = NOW()
+WHERE  t.deleted_at IS NOT NULL
+AND    EXISTS (
+         SELECT 1 FROM transaction_journals tj
+         WHERE  tj.id = t.transaction_journal_id
+         AND    tj.description LIKE '%<pattern>%'
+       );
+```
+
+Then, **always**, from the app container:
+```bash
+scripts/ff-artisan.sh cache:clear
+scripts/ff-artisan.sh firefly-iii:correct-database
+scripts/ff-artisan.sh firefly-iii:refresh-running-balance --force
+```
+
+## Other useful direct queries
+
+### Find duplicates by external_id
+
+```sql
+SELECT jm.data AS external_id, COUNT(*) c, GROUP_CONCAT(jm.transaction_journal_id) journals
+FROM   journal_meta jm
+WHERE  jm.name = 'external_id'
+GROUP  BY jm.data
+HAVING c > 1;
+```
+
+### Orphaned `transactions` (parent journal missing or deleted)
+
+```sql
+SELECT t.id, t.transaction_journal_id, t.account_id, t.amount
+FROM   transactions t
+LEFT   JOIN transaction_journals tj ON tj.id = t.transaction_journal_id
+WHERE  t.deleted_at IS NULL
+AND    (tj.id IS NULL OR tj.deleted_at IS NOT NULL);
+```
+
+Fix via `firefly-iii:removes-orphaned-transactions` (or the umbrella `correct-database`).
+
+### Journals whose two `transactions` rows don't sum to zero
+
+```sql
+SELECT t.transaction_journal_id, ROUND(SUM(t.amount), 4) total
+FROM   transactions t
+WHERE  t.deleted_at IS NULL
+GROUP  BY t.transaction_journal_id
+HAVING total <> 0;
+```
+
+Fix via `firefly-iii:corrects-uneven-amount`.
+
+### Spend per asset account this month
+
+```sql
+SELECT a.id, a.name, SUM(t.amount) AS net_change_eur
+FROM   transactions t
+JOIN   transaction_journals tj ON tj.id = t.transaction_journal_id
+JOIN   accounts a ON a.id = t.account_id
+JOIN   account_types at ON at.id = a.account_type_id
+WHERE  at.type = 'Asset account'
+AND    tj.date >= '2026-05-01' AND tj.date < '2026-06-01'
+AND    tj.deleted_at IS NULL AND t.deleted_at IS NULL
+GROUP  BY a.id, a.name;
+```
+
+### List Personal Access Tokens (debug-only — does not expose the JWT)
+
+```sql
+SELECT id, user_id, client_id, name, scopes, revoked, expires_at, created_at
+FROM   oauth_access_tokens
+WHERE  revoked = 0;
+```
+
+### Find the user's Passport "Personal Access Client"
+
+```sql
+SELECT * FROM oauth_clients WHERE personal_access_client = 1;
+```
+
+If this row is missing after an OAuth wipe, Firefly's UI won't let you create new Personal Access Tokens. Run `php artisan passport:client --personal` to recreate.
+
+## Backups + restore notes
+
+- The canonical backup is the MariaDB dump (see `workflows.md` workflow 16). Restore via:
+  ```bash
+  gunzip -c firefly-db.sql.gz | docker exec -i $DB mariadb -u firefly -p"$DB_PASS" firefly
+  ```
+- File attachments live on the `firefly_upload` volume. Their DB rows have a `hash` column (SHA-256) — after restore run `firefly-iii:scan-attachments` so Firefly re-checksums and re-mimes.
+- OAuth keys (`storage/oauth-{public,private}.key`) live on the `firefly_storage` named volume, so they survive container recreate and Personal Access Tokens stay valid across redeploys. If the volume is lost (e.g. wiped in a recovery), all PATs become invalid simultaneously; rotate the `firefly_access_token` secret via the procedure in `services/firefly/README.md` (§ *Rotating `firefly_access_token`*).

--- a/.claude/skills/firefly/references/importer.md
+++ b/.claude/skills/firefly/references/importer.md
@@ -1,0 +1,162 @@
+# Firefly III Data Importer
+
+The Data Importer (`fireflyiii/data-importer:latest`, currently v2.3.2 on this stack) is a separate service that ingests **CSV files**, **Spectre** statements, **Nordigen/GoCardless** PSD2 feeds, **camt.053** XML, and **Lunch Flow** JSON pushes — then POSTs them through Firefly's API as ordinary transactions.
+
+This stack runs it as service `firefly_importer`, container `firefly-importer`, internal URL `http://firefly-importer:8080`, public URL `https://firefly-importer.home` (LAN) / `https://firefly-importer.giocaizzi.xyz` (Cloudflare).
+
+The two surfaces:
+
+1. **UI flow** — uploads → preview → import. Used once to *produce* a JSON config you can rerun.
+2. **Auto-import flow** — drop files + the saved config into `/var/www/html/import/` inside the container, then POST `/autoimport`. This is what the nightly cron and Lunch Flow integration use.
+
+## OAuth setup (one-time, after a fresh deploy)
+
+The importer needs a Firefly III **OAuth Personal Access Client** (different from a Personal Access Token).
+
+1. Firefly UI → Profile → OAuth → **Create New Personal Access Client**.
+   - Name: `Data Importer`
+   - Redirect URL: `https://firefly-importer.home/callback`
+   - **Uncheck** *Confidential*.
+2. Copy the resulting **Client ID** (integer).
+3. Create the Swarm secret:
+   ```bash
+   echo -n "<client_id>" | ssh giorgiocaizzi@pi.local 'docker secret create firefly_client_id -'
+   ```
+4. `docker service update --force firefly_importer` so the new secret mounts.
+5. Visit `https://firefly-importer.home`, log in via Firefly when prompted; the importer stores its access token in its own session and is ready.
+
+## Auto-import — what's wired up
+
+The `firefly-scheduler` Alpine container has a cron entry that nightly POSTs:
+
+```
+POST /autoimport?directory=/var/www/html/import&secret=$AUTO_IMPORT_SECRET
+Authorization: Bearer $FIREFLY_ACCESS_TOKEN
+```
+
+`AUTO_IMPORT_SECRET` is the `firefly_auto_import_secret` Swarm secret (gate so a random visitor can't trigger imports). `FIREFLY_ACCESS_TOKEN` is the Firefly Personal Access Token, used by the importer to call back into Firefly.
+
+The endpoint iterates files in `/var/www/html/import/` (which is `firefly_upload` shared with the app). For each `*.json` config it finds, it imports the matching data file (`<name>.csv` or whatever the config references).
+
+## Triggering an auto-import manually
+
+The endpoint **requires** the bearer token; an empty body POST without it returns 401. The token lives in the scheduler's mounted secret:
+
+```bash
+ssh giorgiocaizzi@pi.local "
+  SCHED=\$(docker ps --filter 'label=com.docker.swarm.service.name=firefly_scheduler' --format '{{.Names}}' | head -1)
+  TOKEN=\$(docker exec \$SCHED cat /run/secrets/firefly_access_token)
+
+  IMP=\$(docker ps --filter 'label=com.docker.swarm.service.name=firefly_importer' --format '{{.Names}}' | head -1)
+  SECRET=\$(docker exec \$IMP cat /run/secrets/auto_import_secret)
+
+  docker exec \$IMP curl -sS -X POST \
+    -H 'Accept: application/json' \
+    -H \"Authorization: Bearer \${TOKEN}\" \
+    \"http://localhost:8080/autoimport?directory=/var/www/html/import&secret=\${SECRET}\"
+"
+```
+
+Expected: HTTP 200 with `{"message":"Seems to have worked!"}`. Inspect the run:
+```bash
+ssh giorgiocaizzi@pi.local 'docker service logs --tail 400 -f firefly_importer'
+```
+
+Per-row `422 a115` ("duplicate hash") messages are **benign** — they mean the row was already imported. The default config has `IGNORE_DUPLICATE_ERRORS=false`, so the per-row error is logged but the batch continues.
+
+## Updating the importer config (Swarm config rotation)
+
+The importer reads `/var/www/html/import/config.json`, supplied as the Swarm config `firefly_importer_config`. Swarm configs are **immutable** — you cannot edit in place. Scaling the service to 0 is **not** enough because the service spec still references the config and holds a lock. The full rotation:
+
+```bash
+scp services/firefly/config/config.json giorgiocaizzi@pi.local:/tmp/importer_config.json
+ssh giorgiocaizzi@pi.local '
+  docker service update --config-rm firefly_importer_config firefly_importer &&
+  docker config rm firefly_importer_config &&
+  docker config create firefly_importer_config /tmp/importer_config.json &&
+  rm /tmp/importer_config.json &&
+  docker service update \
+    --config-add source=firefly_importer_config,target=/var/www/html/import/config.json,mode=0444 \
+    firefly_importer &&
+  docker service scale firefly_importer=1
+'
+```
+
+The four commands are: detach config from service → delete config → create new config from file → re-attach → ensure replica is up.
+
+> `services/firefly/config/config.json` is **gitignored** because it contains the Firefly access token field (`"access_token": "eyJ..."`). Never commit it.
+
+## Config shape (CSV import)
+
+Minimal fields you almost always set:
+
+```json
+{
+  "version": 3,
+  "source": "csv",
+  "created_at": "...",
+  "date": "Ymd",
+  "delimiter": "comma",
+  "headers": true,
+  "rules": true,
+  "skip_form": false,
+  "add_import_tag": true,
+  "default_account": 1,
+  "ignore_duplicate_transactions": true,
+  "ignore_duplicate_lines": true,
+  "specifics": [],
+  "roles": [
+    "date_transaction", "description", "amount", "opposing-name", "external-id"
+  ],
+  "do_mapping": [false, false, false, true, false],
+  "mapping": {
+    "3": {
+      "AMZN MKTPLACE": 42,        // opposing column -> Firefly account id
+      "TFL TRAVEL": 17
+    }
+  },
+  "duplicate_detection_method": "classic",
+  "unique_column_index": 4,
+  "unique_column_type": "external-id",
+  "flow": "csv"
+}
+```
+
+Generate this from the UI rather than authoring by hand: upload a sample CSV, walk the wizard, then **Download configuration** at the end of the preview step. Drop the file into `services/firefly/config/config.json` and use the rotation command above to push it.
+
+Place the actual data CSV next to the config under `/var/www/html/import/`. For multiple feeds, name each pair the same: `<feed>.json` + `<feed>.csv`. The importer auto-pairs by basename.
+
+## Lunch Flow integration
+
+[Lunch Flow](https://www.lunchflow.app/) is a SaaS that aggregates EU bank feeds and pushes them to the importer's "Lunch Flow" destination.
+
+1. Sign up, connect banks.
+2. In Lunch Flow → **Destinations → Add → API → Firefly III**.
+3. Set the destination URL to `https://firefly-importer.giocaizzi.xyz`.
+4. Copy the API key into the secret:
+   ```bash
+   echo -n "<api_key>" | ssh giorgiocaizzi@pi.local 'docker secret create firefly_lunch_flow_api_key -'
+   docker service update --force firefly_importer
+   ```
+5. Lunch Flow now POSTs new transactions directly; you don't need the autoimport cron for it.
+
+## Spectre / Nordigen (PSD2 bank feeds)
+
+If you choose to drive imports from the importer's built-in PSD2 connectors instead of Lunch Flow:
+
+- Spectre: set `SPECTRE_APP_ID` + `SPECTRE_SECRET` env in the compose service (don't bake into the image — use secrets).
+- Nordigen / GoCardless: set `NORDIGEN_ID` + `NORDIGEN_KEY`.
+- Then UI flow: → Spectre/Nordigen → pick institution → consent → preview → import. The generated config can be reused via auto-import the same way as CSV.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `401 Unauthenticated` on `/autoimport` | Wrong/expired Personal Access Token | Rotate `firefly_access_token` secret + `service update --force firefly_scheduler` |
+| `403 Forbidden` on `/autoimport` | Bad `?secret=` query param | Check `firefly_auto_import_secret` matches `AUTO_IMPORT_SECRET` env |
+| `422 a115` floods | Reimport of already-stored rows | Expected with `IGNORE_DUPLICATE_ERRORS=false`; safe to ignore |
+| `503 Service Unavailable` from importer | Importer can't reach `firefly-app` | Check `firefly_network` overlay is up; `docker exec firefly-importer wget -qO- http://firefly-app:8080/api/v1/about` |
+| Config update hangs | Swarm config lock still held | Re-run the 4-step rotation; verify with `docker config ls \| grep firefly_importer_config` |
+| Importer logs `Could not parse JSON config` | Stale/malformed `config.json` | Regenerate from UI, redo rotation |
+| Lunch Flow shows "delivery failed" | Cloudflare tunnel down or API key mismatch | Test `https://firefly-importer.giocaizzi.xyz/api/v1/import` reachable; verify `firefly_lunch_flow_api_key` |
+| Imported transactions don't get tagged | `add_import_tag: false` in config, or rules disabled (`"rules": false`) | Flip both true, re-run import (will dedupe via `external_id`) |

--- a/.claude/skills/firefly/references/workflows.md
+++ b/.claude/skills/firefly/references/workflows.md
@@ -1,0 +1,440 @@
+# End-to-end workflows
+
+Recipes that string together API calls, CLI commands, and (rarely) SQL. Each one is a complete operational script — copy, fill in the placeholders, run. All commands assume `scripts/ff-api.sh` and `scripts/ff-artisan.sh` are on `$PATH` or invoked with their relative path.
+
+## Table of contents
+- [1. First-time setup of a Personal Access Token](#1-first-time-setup-of-a-personal-access-token)
+- [2. Create an asset account and an opening balance](#2-create-an-asset-account-and-an-opening-balance)
+- [3. Record a single transaction (withdrawal / deposit / transfer)](#3-record-a-single-transaction-withdrawal--deposit--transfer)
+- [4. Split a transaction](#4-split-a-transaction)
+- [5. Record a foreign-currency transaction](#5-record-a-foreign-currency-transaction)
+- [6. Bulk import historical CSV via the API (small files)](#6-bulk-import-historical-csv-via-the-api-small-files)
+- [7. Bulk import via the Data Importer (large files / Lunch Flow)](#7-bulk-import-via-the-data-importer-large-files--lunch-flow)
+- [8. Set up a category, budget, and limit; assign past transactions](#8-set-up-a-category-budget-and-limit-assign-past-transactions)
+- [9. Set up a bill (subscription) and let rules auto-match](#9-set-up-a-bill-subscription-and-let-rules-auto-match)
+- [10. Create a recurring transaction](#10-create-a-recurring-transaction)
+- [11. Build a tagging rule and back-fill it](#11-build-a-tagging-rule-and-back-fill-it)
+- [12. Reconcile an account](#12-reconcile-an-account)
+- [13. Save toward a piggy bank](#13-save-toward-a-piggy-bank)
+- [14. Subscribe to webhook events](#14-subscribe-to-webhook-events)
+- [15. Pull a monthly report](#15-pull-a-monthly-report)
+- [16. Full data export + offsite backup](#16-full-data-export--offsite-backup)
+- [17. Disaster recovery: restore + validate](#17-disaster-recovery-restore--validate)
+
+---
+
+## 1. First-time setup of a Personal Access Token
+
+After deploying Firefly and registering the first user:
+
+1. UI → **Options → Profile → OAuth → Personal Access Tokens → Create New Token**. Give it any name. Copy the JWT — it is shown **once**.
+2. Store on the Pi as the `firefly_access_token` secret:
+   ```bash
+   echo -n "eyJ0eXAi..." | ssh giorgiocaizzi@pi.local 'docker secret create firefly_access_token -'
+   ```
+3. Restart the scheduler so it re-mounts the secret:
+   ```bash
+   ssh giorgiocaizzi@pi.local 'docker service update --force firefly_scheduler'
+   ```
+4. Verify:
+   ```bash
+   scripts/ff-api.sh GET /api/v1/about/user
+   ```
+   Expect a 200 with `data.attributes.email`.
+
+If you ever lose the token, rotate by deleting it in the UI, repeating step 1, and `docker secret rm firefly_access_token` + recreate.
+
+## 2. Create an asset account and an opening balance
+
+```bash
+scripts/ff-api.sh POST /api/v1/accounts '{
+  "name": "Revolut EUR",
+  "type": "asset",
+  "currency_code": "EUR",
+  "account_role": "defaultAsset",
+  "opening_balance": "150.00",
+  "opening_balance_date": "2026-01-01",
+  "iban": "GB00REVO00000000000000",
+  "active": true,
+  "include_net_worth": true
+}'
+```
+
+The opening balance is recorded as a special transaction (`transaction_type_id=4`). To change it later, fetch the account → follow `links.transactions` → `PUT` that transaction group.
+
+## 3. Record a single transaction (withdrawal / deposit / transfer)
+
+The shape is identical; only `type` and source/destination roles change.
+
+**Withdrawal** (asset → expense):
+```bash
+scripts/ff-api.sh POST /api/v1/transactions '{
+  "error_if_duplicate_hash": true,
+  "apply_rules": true,
+  "fire_webhooks": true,
+  "transactions": [{
+    "type": "withdrawal",
+    "date": "2026-05-17",
+    "amount": "4.20",
+    "description": "Espresso",
+    "source_id": 1,
+    "destination_name": "Cafe Pina",
+    "category_name": "Food & Drink",
+    "currency_code": "EUR",
+    "tags": ["coffee"]
+  }]
+}'
+```
+
+**Deposit** (revenue → asset):
+```json
+{"type":"deposit","date":"2026-05-17","amount":"2500.00","description":"Salary",
+ "source_name":"Acme Corp","destination_id":1,"category_name":"Salary","currency_code":"EUR"}
+```
+
+**Transfer** (asset → asset):
+```json
+{"type":"transfer","date":"2026-05-17","amount":"500.00","description":"Move to savings",
+ "source_id":1,"destination_id":2,"currency_code":"EUR"}
+```
+
+Send all of them inside `{"transactions":[...]}`. `external_id` is the idempotency key; set it to the upstream source's transaction ID when importing.
+
+## 4. Split a transaction
+
+A receipt that combines groceries and a coffee: one trip to the store, two journals inside one group.
+
+```bash
+scripts/ff-api.sh POST /api/v1/transactions '{
+  "error_if_duplicate_hash": true,
+  "apply_rules": true,
+  "group_title": "Lidl trip — 17 May",
+  "transactions": [
+    {
+      "type": "withdrawal", "date": "2026-05-17",
+      "amount": "42.10", "description": "Groceries",
+      "source_id": 1, "destination_name": "Lidl",
+      "category_name": "Groceries", "currency_code": "EUR"
+    },
+    {
+      "type": "withdrawal", "date": "2026-05-17",
+      "amount": "1.90", "description": "Coffee",
+      "source_id": 1, "destination_name": "Lidl",
+      "category_name": "Food & Drink", "currency_code": "EUR"
+    }
+  ]
+}'
+```
+
+The group totals to €44.00 from account 1; the per-journal categories let budgets and reports break out the spend.
+
+## 5. Record a foreign-currency transaction
+
+EUR account paying USD (e.g. €92.40 charged for a $100 purchase):
+
+```json
+{
+  "type": "withdrawal",
+  "date": "2026-05-17",
+  "amount": "100.00",             // foreign side: USD
+  "currency_code": "USD",
+  "foreign_amount": "92.40",      // home side: EUR
+  "foreign_currency_code": "EUR",
+  "description": "GitHub Copilot",
+  "source_id": 1,                 // the EUR account
+  "destination_name": "GitHub"
+}
+```
+
+Rule of thumb: `currency_code` + `amount` are what the transaction *was* (foreign); `foreign_*` is what your account *paid* (home). The asset account's currency dictates which side is home — see `/accounts/{id}` `attributes.currency_code`.
+
+## 6. Bulk import historical CSV via the API (small files)
+
+For up to ~1000 rows. Larger goes through the Data Importer (see workflow 7).
+
+1. Use Python/jq to convert your CSV to a stream of `POST /api/v1/transactions` payloads, one per row. Set `external_id` to a stable key from your CSV so reruns are no-ops.
+2. Disable rules during the bulk (`apply_rules: false`) to avoid the action storm.
+3. POST each payload; treat `422 a115` (duplicate hash) as success.
+4. After the bulk, fire the rule groups once:
+   ```bash
+   scripts/ff-api.sh POST '/api/v1/rule-groups/1/trigger?start=2026-01-01&end=2026-05-17'
+   ```
+5. Refresh balances:
+   ```bash
+   scripts/ff-artisan.sh firefly-iii:refresh-running-balance
+   ```
+
+## 7. Bulk import via the Data Importer (large files / Lunch Flow)
+
+Use this for thousands of rows, or for Lunch Flow / Spectre / GoCardless feeds. Full procedure in `references/importer.md`; summary:
+
+1. Generate the import **config** by uploading a sample CSV through `https://firefly-importer.home` UI, then **Download configuration**.
+2. Drop the JSON config into the swarm and rotate the importer's `firefly_importer_config` Swarm config (commands in `references/importer.md`).
+3. Place data files in `/var/www/html/import/` inside the importer container (mounted from `firefly_upload`).
+4. Trigger:
+   ```bash
+   scripts/ff-api.sh POST '/autoimport?directory=/var/www/html/import&secret=<auto_import_secret>'
+   ```
+   (use the dedicated `ff-importer-api` invocation in `references/importer.md`)
+5. Watch logs: `ssh giorgiocaizzi@pi.local 'docker service logs --tail 200 -f firefly_importer'`.
+
+## 8. Set up a category, budget, and limit; assign past transactions
+
+```bash
+# 1. Category
+CAT=$(scripts/ff-api.sh POST /api/v1/categories '{"name":"Groceries"}' | jq -r '.data.id')
+
+# 2. Budget (named bucket)
+BUD=$(scripts/ff-api.sh POST /api/v1/budgets '{"name":"Food","active":true}' | jq -r '.data.id')
+
+# 3. Budget limit for May
+scripts/ff-api.sh POST "/api/v1/budgets/$BUD/limits" '{
+  "start":"2026-05-01","end":"2026-05-31",
+  "amount":"400.00","currency_code":"EUR"
+}'
+
+# 4. Tag historical transactions with this category via bulk patch
+scripts/ff-api.sh POST /api/v1/data/bulk/transactions "$(jq -n --arg q "category:none destination:Lidl" --argjson c "$CAT" '
+  {query:{search:$q},update:{category_id:$c}}')"
+```
+
+After the bulk update, `GET /api/v1/insight/expense/category?start=2026-05-01&end=2026-05-31` reflects the change.
+
+## 9. Set up a bill (subscription) and let rules auto-match
+
+Bills are "expected payments". Firefly only auto-matches if a rule links transactions to the bill.
+
+```bash
+# 1. Create the bill
+BILL=$(scripts/ff-api.sh POST /api/v1/bills '{
+  "name":"Netflix","amount_min":"12.99","amount_max":"13.99",
+  "date":"2026-01-15","repeat_freq":"monthly","skip":0,
+  "currency_code":"EUR","active":true
+}' | jq -r '.data.id')
+
+# 2. Create a rule that links matching transactions to the bill
+scripts/ff-api.sh POST /api/v1/rules "$(jq -n --argjson b "$BILL" '{
+  "title":"Auto-link Netflix",
+  "rule_group_id":1,
+  "trigger":"store-journal",
+  "strict":true,"stop_processing":false,"active":true,
+  "triggers":[
+    {"type":"description_contains","value":"NETFLIX"},
+    {"type":"amount_more","value":"12.00"},
+    {"type":"amount_less","value":"14.00"}
+  ],
+  "actions":[
+    {"type":"link_to_bill","value":($b|tostring),"order":1}
+  ]
+}')"
+
+# 3. Back-fill against existing transactions
+scripts/ff-api.sh POST "/api/v1/rule-groups/1/trigger?start=2026-01-01&end=2026-05-17"
+```
+
+## 10. Create a recurring transaction
+
+```bash
+scripts/ff-api.sh POST /api/v1/recurrences '{
+  "title":"Rent",
+  "first_date":"2026-06-01",
+  "active":true,
+  "apply_rules":true,
+  "repetitions":[{"type":"monthly","moment":"1","skip":0,"weekend":1}],
+  "transactions":[{
+    "description":"Rent payment",
+    "amount":"850.00",
+    "type":"withdrawal",
+    "currency_code":"EUR",
+    "source_id":1,
+    "destination_name":"Landlord",
+    "category_name":"Housing",
+    "tags":["recurring"]
+  }],
+  "notes":""
+}'
+```
+
+Force a one-off run (e.g. to back-fill a missed cycle):
+```bash
+scripts/ff-api.sh POST /api/v1/recurrences/$REC_ID/trigger
+```
+
+Recurrences are realised by `firefly-iii:cron`. To run cron for a specific past date:
+```bash
+scripts/ff-artisan.sh firefly-iii:cron --date=2026-06-01 --force
+```
+
+## 11. Build a tagging rule and back-fill it
+
+Tag every Uber/Lyft as `transport`:
+
+```bash
+scripts/ff-api.sh POST /api/v1/rules '{
+  "title":"Tag ridesharing",
+  "rule_group_id":1,
+  "trigger":"store-journal",
+  "strict":false,
+  "stop_processing":false,
+  "active":true,
+  "triggers":[
+    {"type":"description_contains","value":"UBER"},
+    {"type":"description_contains","value":"LYFT"}
+  ],
+  "actions":[
+    {"type":"add_tag","value":"transport","order":1},
+    {"type":"set_category","value":"Transport","order":2}
+  ]
+}'
+```
+
+Note `strict:false` — it's an OR rule (matches either trigger). With `strict:true` all triggers must hit. Back-fill:
+```bash
+scripts/ff-api.sh POST "/api/v1/rules/$RULE_ID/trigger?start=2026-01-01&end=2026-05-17"
+```
+
+For huge ranges, use the CLI `firefly-iii:apply-rules --rules=$RULE_ID` instead — it's faster and uses less memory.
+
+## 12. Reconcile an account
+
+Reconciliation = "as of date X, the account balance should be Y; create a balancing journal if not."
+
+The API does not expose a dedicated reconciliation endpoint; create a reconciliation transaction directly:
+```bash
+scripts/ff-api.sh POST /api/v1/transactions '{
+  "transactions":[{
+    "type":"reconciliation",
+    "date":"2026-05-17",
+    "amount":"3.45",
+    "description":"Reconciliation 2026-05-17",
+    "source_id":1,
+    "destination_name":"Reconciliation account",
+    "reconciled":true
+  }]
+}'
+```
+
+The sign convention: amount is positive, direction is implied by `source`/`destination` (asset → reconciliation = correction down; reconciliation → asset = correction up). Firefly flags reconciled journals and dims them in the UI.
+
+## 13. Save toward a piggy bank
+
+```bash
+# Create piggy bank
+PIG=$(scripts/ff-api.sh POST /api/v1/piggy-banks '{
+  "name":"Iceland trip",
+  "accounts":[{"id":1,"current_amount":"0"}],
+  "target_amount":"1500.00",
+  "start_date":"2026-01-01","target_date":"2026-12-31"
+}' | jq -r '.data.id')
+
+# Add €100 toward it (creates a piggy-bank event, no new tx)
+# Note: piggy-bank balance changes happen via piggy-bank events, which Firefly
+# exposes through transaction notes (`add_amount` field on the transaction store).
+# The supported way is to record a transfer into the goal-linked account and
+# mark the piggy bank via the journal note "piggyBank=<id>:+100".
+```
+
+Piggy banks reflect intentions, not money movements — the cash stays in the asset account. Firefly recalculates the piggy total nightly via `firefly-iii:corrects-piggy-banks`.
+
+## 14. Subscribe to webhook events
+
+Wire Firefly to your home automation:
+```bash
+scripts/ff-api.sh POST /api/v1/webhooks '{
+  "title":"Notify HA on new transaction",
+  "active":true,
+  "trigger":"STORE_TRANSACTION",
+  "response":"TRANSACTIONS",
+  "delivery":"JSON",
+  "url":"https://hass.home/api/webhook/firefly_new_tx"
+}'
+```
+
+Inspect deliveries:
+```bash
+scripts/ff-api.sh GET /api/v1/webhooks/$WH_ID/messages
+scripts/ff-api.sh GET /api/v1/webhooks/$WH_ID/messages/$MSG_ID/attempts
+```
+
+Receivers should verify the `X-Firefly-Signature` header (HMAC-SHA3-256 of the body using the webhook secret).
+
+## 15. Pull a monthly report
+
+Numbers for May 2026:
+
+```bash
+START=2026-05-01; END=2026-05-31; CUR=EUR
+
+scripts/ff-api.sh GET "/api/v1/summary/basic?start=$START&end=$END&currency_code=$CUR"
+
+# Per-category spend
+scripts/ff-api.sh GET "/api/v1/insight/expense/category?start=$START&end=$END"
+
+# Per-budget spend vs. limit
+scripts/ff-api.sh GET "/api/v1/insight/expense/budget?start=$START&end=$END"
+
+# Net per asset account
+scripts/ff-api.sh GET "/api/v1/chart/account/overview?start=$START&end=$END"
+```
+
+For a CSV instead of JSON aggregations:
+```bash
+scripts/ff-api.sh GET "/api/v1/data/export/transactions?start=$START&end=$END&type=csv" > may.csv
+```
+
+## 16. Full data export + offsite backup
+
+```bash
+# 1. CLI export (everything)
+scripts/ff-artisan.sh firefly-iii:export-data \
+  --token=$(ssh giorgiocaizzi@pi.local 'docker exec $(docker ps -qf label=com.docker.swarm.service.name=firefly_scheduler | head -1) cat /run/secrets/firefly_access_token') \
+  --export_directory=/var/www/html/storage/upload \
+  --export-transactions --export-accounts --export-budgets \
+  --export-categories --export-tags --export-recurring \
+  --export-rules --export-subscriptions --export-piggies --force
+
+# 2. Pull files from the volume
+ssh giorgiocaizzi@pi.local 'sudo tar czf /tmp/firefly-export.tar.gz -C /var/lib/docker/volumes/firefly_firefly_upload/_data .'
+scp giorgiocaizzi@pi.local:/tmp/firefly-export.tar.gz ./
+ssh giorgiocaizzi@pi.local 'rm /tmp/firefly-export.tar.gz'
+
+# 3. DB dump (canonical backup)
+ssh giorgiocaizzi@pi.local '
+  APP=$(docker ps -qf label=com.docker.swarm.service.name=firefly_app | head -1)
+  DB=$(docker ps -qf label=com.docker.swarm.service.name=firefly_db | head -1)
+  DB_PASS=$(docker exec $APP cat /run/secrets/db_password)
+  docker exec $DB mariadb-dump -u firefly -p"$DB_PASS" firefly | gzip > /tmp/firefly-db.sql.gz
+'
+scp giorgiocaizzi@pi.local:/tmp/firefly-db.sql.gz ./
+ssh giorgiocaizzi@pi.local 'rm /tmp/firefly-db.sql.gz'
+```
+
+The repo's Backrest stack handles this on schedule; manual runs above are for ad-hoc snapshots.
+
+## 17. Disaster recovery: restore + validate
+
+1. Restore the MariaDB dump into a fresh `firefly_db` volume.
+2. Restore the `firefly_upload` volume from its archive.
+3. Bring up the stack.
+4. Restore OAuth keys (Personal Access Tokens stay valid only if `storage/oauth-{public,private}.key` were backed up; otherwise:):
+   ```bash
+   scripts/ff-artisan.sh correction:restore-oauth-keys
+   scripts/ff-artisan.sh firefly-iii:laravel-passport-keys
+   scripts/ff-artisan.sh cache:clear
+   ```
+5. Reset the Personal Access Token (UI → Profile → OAuth → Personal Access Tokens; old tokens won't work if keys were regenerated). Re-create the `firefly_access_token` Swarm secret and `docker service update --force firefly_scheduler`.
+6. Repair the DB:
+   ```bash
+   scripts/ff-artisan.sh firefly-iii:report-integrity
+   scripts/ff-artisan.sh firefly-iii:correct-database
+   scripts/ff-artisan.sh firefly-iii:refresh-running-balance --force
+   ```
+7. Re-attach attachments:
+   ```bash
+   scripts/ff-artisan.sh firefly-iii:scan-attachments
+   ```
+8. Smoke-test:
+   ```bash
+   scripts/ff-api.sh GET /api/v1/about
+   scripts/ff-api.sh GET /api/v1/summary/basic?start=2026-01-01&end=2026-12-31&currency_code=EUR
+   ```

--- a/.claude/skills/firefly/scripts/ff-api.sh
+++ b/.claude/skills/firefly/scripts/ff-api.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# ff-api.sh — authenticated curl against the Firefly III REST API.
+#
+# Resolves the Personal Access Token from the firefly_access_token swarm secret
+# mounted in the firefly_scheduler container, then exec'es curl inside the
+# firefly_app container so the request stays on the rp5_firefly overlay network
+# and the token never crosses the host shell.
+#
+# Usage:
+#   ff-api.sh <METHOD> <PATH> [BODY]
+#
+#   METHOD  HTTP verb (GET | POST | PUT | DELETE | PATCH)
+#   PATH    Path beginning with "/api/v1/..." OR a fully-qualified URL on the
+#           public host (https://firefly.giocaizzi.xyz/...). A bare path is
+#           sent against http://localhost:8080 inside the app container.
+#   BODY    Optional. One of:
+#             - inline JSON string:  '{"name":"x"}'
+#             - @/abs/path/to/file:  body read from that file (sent as-is)
+#             - -                  : body read from stdin
+#           Omit for GET/DELETE.
+#
+# Environment:
+#   PI_SSH_USER   SSH user (default: giorgiocaizzi)
+#   PI_HOST       SSH host (default: pi.local)
+#   FF_RAW        If set to "1", print response headers + body, no jq.
+#
+# Examples:
+#   ff-api.sh GET  /api/v1/about
+#   ff-api.sh GET  '/api/v1/accounts?type=asset&limit=100'
+#   ff-api.sh POST /api/v1/transactions @./tx.json
+#   echo '{"name":"Coffee"}' | ff-api.sh POST /api/v1/categories -
+
+set -euo pipefail
+
+PI_SSH_USER="${PI_SSH_USER:-giorgiocaizzi}"
+PI_HOST="${PI_HOST:-pi.local}"
+SSH_TARGET="${PI_SSH_USER}@${PI_HOST}"
+
+usage() {
+  sed -n '2,32p' "$0" >&2
+  exit 64
+}
+
+[ "$#" -lt 2 ] && usage
+
+METHOD="$(echo "$1" | tr '[:lower:]' '[:upper:]')"
+TARGET="$2"
+BODY_ARG="${3-}"
+
+case "$METHOD" in
+  GET|POST|PUT|DELETE|PATCH) ;;
+  *) echo "ff-api: unknown method '$METHOD'" >&2; usage ;;
+esac
+
+# Resolve the URL: bare path => internal; full URL => external.
+if [[ "$TARGET" == http://* || "$TARGET" == https://* ]]; then
+  URL="$TARGET"
+else
+  case "$TARGET" in
+    /*) URL="http://localhost:8080${TARGET}" ;;
+    *)  URL="http://localhost:8080/${TARGET}" ;;
+  esac
+fi
+
+# Materialise the body.
+BODY=""
+case "$BODY_ARG" in
+  "")  ;;                                             # no body
+  -)   BODY="$(cat)" ;;                               # stdin
+  @*)  BODY="$(cat "${BODY_ARG#@}")" ;;               # @file
+  *)   BODY="$BODY_ARG" ;;                            # inline
+esac
+
+# Encode the body so we can ship it through one SSH heredoc without quoting hell.
+B64_BODY=""
+if [ -n "$BODY" ]; then
+  B64_BODY="$(printf %s "$BODY" | base64 | tr -d '\n')"
+fi
+
+REMOTE_SCRIPT=$(cat <<'REMOTE'
+set -euo pipefail
+: "${FF_METHOD:?ff-api: FF_METHOD not set}"
+: "${FF_URL:?ff-api: FF_URL not set}"
+B64_BODY="${FF_BODY_B64:-}"
+RAW="${FF_RAW:-0}"
+
+SCHED=$(docker ps --filter 'label=com.docker.swarm.service.name=firefly_scheduler' --format '{{.Names}}' | head -1)
+APP=$(docker ps --filter 'label=com.docker.swarm.service.name=firefly_app' --format '{{.Names}}' | head -1)
+[ -z "$SCHED" ] && { echo "ff-api: firefly_scheduler container not found" >&2; exit 1; }
+[ -z "$APP" ]   && { echo "ff-api: firefly_app container not found" >&2; exit 1; }
+
+TOKEN=$(docker exec "$SCHED" cat /run/secrets/firefly_access_token)
+[ -z "$TOKEN" ] && { echo "ff-api: firefly_access_token secret is empty" >&2; exit 1; }
+
+CURL_ARGS=(-sS -X "$FF_METHOD"
+  -H "Accept: application/json"
+  -H "Authorization: Bearer ${TOKEN}")
+
+[ "$RAW" = "1" ] && CURL_ARGS=(-i "${CURL_ARGS[@]}")
+
+if [ -n "$B64_BODY" ]; then
+  CURL_ARGS+=(-H "Content-Type: application/json" --data-binary "@-")
+  printf %s "$B64_BODY" | base64 -d | docker exec -i "$APP" curl "${CURL_ARGS[@]}" "$FF_URL"
+else
+  docker exec "$APP" curl "${CURL_ARGS[@]}" "$FF_URL"
+fi
+REMOTE
+)
+
+ssh -o BatchMode=yes "$SSH_TARGET" \
+  "FF_METHOD=$(printf %q "$METHOD") \
+   FF_URL=$(printf %q "$URL") \
+   FF_BODY_B64=$(printf %q "$B64_BODY") \
+   FF_RAW=$(printf %q "${FF_RAW:-0}") \
+   bash -s" <<<"$REMOTE_SCRIPT"

--- a/.claude/skills/firefly/scripts/ff-artisan.sh
+++ b/.claude/skills/firefly/scripts/ff-artisan.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# ff-artisan.sh — run `php artisan` inside the firefly_app container.
+#
+# Resolves the running container by Swarm service label so it survives
+# replica re-scheduling. All arguments are forwarded verbatim to artisan.
+#
+# Usage:
+#   ff-artisan.sh <artisan-command> [args ...]
+#
+# Environment:
+#   PI_SSH_USER   SSH user (default: giorgiocaizzi)
+#   PI_HOST       SSH host (default: pi.local)
+#   FF_TTY        Set to "1" to allocate a TTY (for `tinker`, `migrate --pretend`, ...)
+#
+# Examples:
+#   ff-artisan.sh firefly-iii:cron
+#   ff-artisan.sh firefly-iii:report-integrity
+#   ff-artisan.sh firefly-iii:correct-database
+#   ff-artisan.sh firefly-iii:refresh-running-balance --force
+#   FF_TTY=1 ff-artisan.sh tinker
+
+set -euo pipefail
+
+PI_SSH_USER="${PI_SSH_USER:-giorgiocaizzi}"
+PI_HOST="${PI_HOST:-pi.local}"
+SSH_TARGET="${PI_SSH_USER}@${PI_HOST}"
+
+if [ "$#" -lt 1 ]; then
+  sed -n '2,21p' "$0" >&2
+  exit 64
+fi
+
+# Quote each argument for safe transport through `bash -s --`.
+ARGS_QUOTED=""
+for a in "$@"; do
+  ARGS_QUOTED+=" $(printf %q "$a")"
+done
+
+SSH_FLAGS=(-o BatchMode=yes)
+[ "${FF_TTY:-0}" = "1" ] && SSH_FLAGS=(-t)
+
+ssh "${SSH_FLAGS[@]}" "$SSH_TARGET" bash -s -- "${FF_TTY:-0}" <<REMOTE
+set -euo pipefail
+FF_TTY="\$1"; shift
+APP=\$(docker ps --filter 'label=com.docker.swarm.service.name=firefly_app' --format '{{.Names}}' | head -1)
+[ -z "\$APP" ] && { echo "ff-artisan: firefly_app container not found" >&2; exit 1; }
+
+EXEC_FLAGS=()
+[ "\$FF_TTY" = "1" ] && EXEC_FLAGS+=(-it)
+
+docker exec "\${EXEC_FLAGS[@]}" "\$APP" php artisan${ARGS_QUOTED}
+REMOTE

--- a/services/firefly/README.md
+++ b/services/firefly/README.md
@@ -44,6 +44,37 @@
 | `firefly_access_token` | Profile → OAuth → Personal Access Tokens |
 | `firefly_lunch_flow_api_key` | External: [lunchflow.app](https://www.lunchflow.app/) |
 
+### Rotating `firefly_access_token`
+
+A Personal Access Token is a Laravel Passport JWT signed by `storage/oauth-private.key`. Generating a new token in the UI does **not** invalidate the previous one — but losing the key pair does (every JWT signed by the old private key fails verification, all at once). The `firefly_storage` volume persists those keys across container restarts; rotation is only needed when you want to revoke an existing token or when the keys were regenerated (e.g. by a deploy that predated `firefly_storage`).
+
+Naive `docker secret rm` + `create` crash-loops the scheduler container, because its startup script `cat`s the secret. Detach first, then swap, then reattach:
+
+```bash
+# 1. Generate a new token in the Firefly UI (Profile → OAuth → Personal Access Tokens)
+#    and place it in services/firefly/secrets/firefly_access_token.txt (gitignored).
+
+# 2. Rotate the Swarm secret in three steps from the Pi.
+NEW_TOKEN=$(cat services/firefly/secrets/firefly_access_token.txt)
+ssh pi@pi.local "TOKEN=$(printf %q "$NEW_TOKEN") bash -s" <<'EOF'
+set -euo pipefail
+docker service update --secret-rm firefly_access_token firefly_scheduler >/dev/null
+docker secret rm firefly_access_token >/dev/null
+printf %s "$TOKEN" | docker secret create firefly_access_token - >/dev/null
+docker service update \
+  --secret-add source=firefly_access_token,target=firefly_access_token \
+  firefly_scheduler >/dev/null
+EOF
+
+# 3. Confirm
+ssh pi@pi.local '
+  SCHED=$(docker ps -qf "label=com.docker.swarm.service.name=firefly_scheduler" | head -1)
+  docker exec "$SCHED" head -c 30 /run/secrets/firefly_access_token; echo
+'
+```
+
+The scheduler will briefly fail one task while the secret is detached — Swarm reschedules within ~5 s as soon as the new secret is attached.
+
 ---
 
 ## 📖 Initial Setup
@@ -121,9 +152,39 @@ Both run in the `firefly-cron` Alpine container.
 
 ## 💾 Volumes
 
-| Volume | Purpose |
-|--------|---------|
-| `firefly_db` | MariaDB data |
-| `firefly_upload` | User uploads |
+| Volume | Mount | Purpose |
+|--------|-------|---------|
+| `firefly_db` | `/var/lib/mysql` | MariaDB data |
+| `firefly_storage` | `/var/www/html/storage` | Laravel storage tree — **persists `oauth-{public,private}.key`** so Personal Access Tokens survive container recreate. Also keeps `framework/`, `logs/`, `app/`. |
+| `firefly_upload` | `/var/www/html/storage/upload` | User attachments. Nested-mounted inside `firefly_storage` so uploads are isolated from the rest of `storage/` for backups. |
+
+> Without `firefly_storage`, every container recreate regenerates the OAuth signing keys, invalidating every existing Personal Access Token at once. See [Rotating `firefly_access_token`](#rotating-firefly_access_token) for recovery.
+
+### First deploy of `firefly_storage` (one-time)
+
+When the volume is first created, Docker copies `storage/*` from the image — which has no OAuth keys (they are generated at runtime). Passport then writes fresh keys into the empty volume, **invalidating the existing PAT**. Two paths:
+
+1. **Easy path — rotate the PAT once after deploy.** Deploy normally, then follow [Rotating `firefly_access_token`](#rotating-firefly_access_token). Every future redeploy is safe.
+
+2. **Preserve current PAT — pre-seed the volume.** Before the redeploy, copy the running keys into a fresh `firefly_firefly_storage` volume:
+
+   ```bash
+   ssh pi@pi.local '
+     APP=$(docker ps -qf "label=com.docker.swarm.service.name=firefly_app" | head -1)
+     docker cp "$APP":/var/www/html/storage/oauth-private.key /tmp/p.key
+     docker cp "$APP":/var/www/html/storage/oauth-public.key  /tmp/P.key
+     docker volume create firefly_firefly_storage
+     docker run --rm \
+       -v firefly_firefly_storage:/dst -v /tmp:/src alpine sh -c "
+         cp /src/p.key /dst/oauth-private.key &&
+         cp /src/P.key /dst/oauth-public.key &&
+         chown 33:33 /dst/oauth-*.key &&
+         chmod 600  /dst/oauth-*.key
+       "
+     shred -u /tmp/p.key /tmp/P.key
+   '
+   ```
+
+   Then deploy. Docker sees the volume is non-empty and skips the image-copy, so the keys you seeded stay — the existing PAT keeps working.
 
 

--- a/services/firefly/docker-compose.yml
+++ b/services/firefly/docker-compose.yml
@@ -103,6 +103,12 @@ services:
       - static_cron_token
     volumes:
       - ./scripts/load-secrets.sh:/etc/cont-init.d/00-load-secrets:ro
+      # Persist the entire Laravel storage tree — most importantly
+      # storage/oauth-{public,private}.key. Without this, container recreate
+      # regenerates the keys and invalidates every Personal Access Token.
+      - firefly_storage:/var/www/html/storage
+      # Attachments live in a separate volume, nested-mounted so user uploads
+      # survive even if firefly_storage is ever rebuilt.
       - firefly_upload:/var/www/html/storage/upload
     networks:
       - firefly_network
@@ -329,6 +335,8 @@ services:
       <<: *logging-base
 
 volumes:
+  firefly_storage:
+    driver: local
   firefly_upload:
     driver: local
   firefly_db:


### PR DESCRIPTION
## Summary

- **New skill** at `.claude/skills/firefly/` — end-to-end runbook covering the REST API (every `/api/v1/*` resource, auth, pagination, error model), the artisan CLI (every `firefly-iii:*`, `correction:*`, `integrity:*`, `system:*` command), 17 e2e workflows, the MariaDB schema with soft-delete rollback semantics, and the Data Importer. Two helper scripts (`ff-api.sh`, `ff-artisan.sh`) read the PAT from the scheduler's mounted secret over SSH so it never crosses the host shell.
- **Persist Firefly's OAuth keys** via a new `firefly_storage` named volume mounted at `/var/www/html/storage`. Container recreate previously regenerated `storage/oauth-{public,private}.key`, invalidating every Personal Access Token at once (root cause of the recent PAT outage). `firefly_upload` stays nested-mounted inside so attachments remain isolated for backups.
- **README** — new `Rotating firefly_access_token` procedure (detach → swap → reattach, avoids scheduler crash-loop) and a `First deploy of firefly_storage (one-time)` warning with a pre-seed flow if you want to preserve the current PAT through this deploy.

## Why this is one PR

The skill and the compose fix are tightly coupled — the skill explicitly references the README's rotation procedure rather than duplicating it, and `db.md` no longer carries the "OAuth keys aren't persisted" footgun warning because the compose change resolves it.

## Deploy note ⚠️

The first deploy of `firefly_storage` will trigger one PAT regeneration unless you pre-seed the volume. Two paths documented in `services/firefly/README.md` § *First deploy of firefly_storage*:

- **Easy**: deploy, then rotate the PAT once (procedure in the same README).
- **Preserve**: copy current `oauth-*.key` into the volume before redeploy.

Every redeploy after this one is safe regardless.

## Test plan

- [ ] `docker compose -f services/firefly/docker-compose.yml config -q` passes (verified locally)
- [ ] Portainer redeploys cleanly after merge
- [ ] `firefly_storage` volume is created on first deploy
- [ ] After PAT rotation (or pre-seed), `./.claude/skills/firefly/scripts/ff-api.sh GET /api/v1/about` returns 200
- [ ] Force a `firefly_app` recreate post-deploy and confirm the PAT still works (proves persistence)
- [ ] `firefly-iii:cron` and the autoimport cron both fire next morning

🤖 Generated with [Claude Code](https://claude.com/claude-code)