### PR TITLE
feat(firefly): auto-reconcile CC on the 11th of each month

### DIFF
--- a/.claude/skills/firefly-logic/SKILL.md
+++ b/.claude/skills/firefly-logic/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: firefly-logic
+description: The user's personal Firefly III domain model — what each account, feed, and rule means in real life; the decisions and invariants that shape how money is recorded. Load this BEFORE doing any operational work via the `firefly` skill (which only covers the HOW). Use whenever the user asks about their money, accounts, balances, Revolut, credit card statements, salary, rent, subscriptions, categorization, or any "fix my Firefly" task — even when they don't name a stack. The `firefly` skill knows the buttons; this skill knows what they're supposed to mean.
+---
+
+# Firefly logic — user's personal domain model
+
+This skill captures the user's high-level mental model of their Firefly III instance. It is intentionally *not* operational: how to call the API, where the importer config lives, how to rotate secrets — all that lives in the sibling `firefly` skill. Read this first to know what the moving parts *mean*, then go there to act.
+
+The instance is single-user (`giocaizzi@gmail.com`), Italian context (descriptions and merchant names are mixed Italian/English), EUR-default.
+
+## 1. The accounts in real life
+
+| Firefly account | id | type | What it actually is |
+|---|---:|---|---|
+| `fineco` | 1 | asset (EUR) | Primary Fineco current account. The hub: salary lands here, all SDD direct debits and card top-ups go out from here. Source of truth via LunchFlow feed. |
+| `revolut` | 5 | asset (EUR) | Revolut EUR wallet. Funded by Fineco top-ups (debit or credit card via Apple Pay). Used for daily card spending. Source of truth via LunchFlow feed. |
+| `Carta Credito Fineco` | 3848 | ccAsset (EUR) | Fineco credit card. Statement settles around the 10th of the following month via `fineco → Carta Credito Fineco` transfer ("ESTRATTO CONTO AL …"). Manual CSV imports only — see §3. |
+| `Revolut USD` | 3821 | asset (USD) | Small USD wallet, occasionally used for travel. Kept. |
+| `revolut GBP` | 1025 | asset (GBP) | Dormant (last activity Feb 2024). One legacy £2.38 exchange transaction. |
+| `Findomestic` | 4104 | liability (loan) | Open consumer loan. Monthly SDD repayment from Fineco. |
+
+Cards in active use:
+- **Fineco debit** ends `*9467` (truncated to `*467` in some statements)
+- **Fineco credit** ends `*3488`
+- Any other last-4 (`*9123`, `*3362`, `*946`, …) is old/tokenized/internal — never assume it maps to a current physical card.
+
+## 2. Data sources and what they're trusted for
+
+| Source | What it feeds | Reliable for |
+|---|---|---|
+| **LunchFlow** (`firefly_importer` auto-import) | `fineco` EUR, `revolut` EUR | Continuous, authoritative current activity. New transactions land via `POST /autoimport`. |
+| **Manual CSV** (`services/firefly/config/conifg_credit.json`) | `Carta Credito Fineco` | Categorisation only — imports are sporadic ("when I remember"). **Balance is never authoritative.** |
+| **Manual entry / UI** | Anything | Used to fill gaps and to fix one-off mismatches. |
+
+**Implication:** when somebody (you, the user) asks "what's my balance on X?" — trust the Fineco/Revolut LunchFlow-fed accounts and hedge on the credit card.
+
+## 3. The credit card mental model
+
+`Carta Credito Fineco` (3848) is an `asset` with `account_role: ccAsset`. Negative balance = money owed to the bank.
+
+### How the money actually flows
+
+1. Card purchases accumulate during the month. LunchFlow does **not** see them — Fineco's API doesn't expose intra-cycle CC purchases. They are invisible to Firefly until the user manually imports a CSV.
+2. On ~10th of the following month, Fineco posts a single **`ESTRATTO CONTO AL …`** debit on the main account that pays the entire prior-month statement. This is visible via LunchFlow and lands on Firefly as a `fineco → Carta Credito Fineco` **transfer** (thanks to rule 9 — see below).
+3. The user pays in full each cycle. Real bank-side CC balance is therefore ≈ 0 right after each settlement, drifting negative as new purchases accumulate over the next ~30 days.
+
+### How it's modelled
+
+| Real-world event | Firefly journal | Source |
+|---|---|---|
+| CC purchase | `Carta Credito Fineco → <Merchant>` withdrawal | CSV import (sporadic) |
+| Apple-Pay top-up to Revolut funded via CC | `Carta Credito Fineco → revolut` transfer | CSV import |
+| Refund / chargeback | `Rimborsi → Carta Credito Fineco` deposit | CSV import (canonical revenue = `Rimborsi`; never create per-merchant revenue accounts for refunds) |
+| Monthly settlement | `fineco → Carta Credito Fineco` transfer | LunchFlow, routed by rule 9 |
+
+### Rule 9 — the ESTRATTO router
+
+`[transfer] Addebito Carta Credito Fineco` (id 9, group `System`):
+- Trigger: `description_contains='CARTA DI CREDITO DI FINECOBANK'`
+- Action 1: `convert_transfer='Carta Credito Fineco'` — converts the inbound withdrawal into a transfer to the CC **asset** (not an expense bucket of the same name)
+- Action 2: `clear_category`
+- `stop_processing: true`
+
+If this rule loses the `convert_transfer` action, the importer silently creates a *phantom expense* account also named "Carta Credito Fineco" and the asset stops getting credited — drift accumulates fast. (This is exactly what happened between 2026-03-10 and 2026-05-17; the May 17 audit fixed rule 9 and repointed the 3 misclassified settlements to the asset.)
+
+### Asymmetric feeds → structural drift, by design
+
+Settlements arrive continuously and completely via LunchFlow. Purchases arrive sporadically via manual CSV. **The CC balance in Firefly lags reality between CSV imports** — that's the cost of not running a full PSD2 feed on the card. Chasing per-transaction completeness is not the goal.
+
+### Auto-reconciliation: pin to 0 on the 11th of each month
+
+A cron job in `firefly_scheduler` runs on the **11th at 04:00** (one day after each ESTRATTO) and posts a native Firefly **reconciliation transaction** that brings the CC balance to exactly 0:
+
+- Script: `services/firefly/scripts/cc_monthly_reconcile.py`.
+- Defensive: only fires if a `fineco → CC` transfer occurred within the last 14 days. If LunchFlow lagged or the ESTRATTO never arrived, the job logs and skips instead of blindly zeroing.
+- Idempotent: if the balance is already 0, it does nothing.
+- Native reconciliation = excluded from spending reports / charts / category totals; the paired reconciliation account (auto-created by Firefly) absorbs the offsetting side and is excluded from net worth.
+- Reconciliation direction: `source = reconciliation account, destination = CC, amount = -balance` (positive amount brings a negative CC balance up toward 0).
+
+This means right after each settlement the CC balance shows the truth (0 = paid in full). As you upload CSVs through the next cycle, the balance drifts negative — that's "what I've categorised this cycle so far", not the real bank balance. On the next 11th, the cron re-pins to 0.
+
+### Never edit `opening_balance` to mask drift
+
+`opening_balance` represents the real CC owed amount the day Firefly started tracking — nothing else. Editing it post-creation silently rewrites the genesis journal with no audit trail and violates the user's invariant on native reconciliation. If you find yourself wanting to nudge the opening balance, use a reconciliation transaction instead.
+
+### Card-number heuristics
+
+If a description mentions card `*3488`, it belongs on `Carta Credito Fineco`. If it shows `*9467` (or `*467`), it belongs on `fineco`. Apple-Pay top-ups can be either card — use the `9123/3362/4841/7528/8976` tokens only as hints, never as ground truth.
+
+## 4. PayPal — excluded from the model
+
+PayPal is **not** part of the model. There is no PayPal asset account. PayPal-mediated money flows are recorded as if PayPal didn't exist:
+
+- A purchase paid via PayPal becomes `Fineco/CC → <Merchant>` (one transaction). The fact that PayPal was the intermediary is invisible in the ledger.
+- When the bank statement does not name the underlying merchant (e.g. raw `"PayPal Europe S.a.r.l. … Mand 4RNJ…/PAYP"` lines from the LunchFlow Fineco feed), the destination is the **expense account `PayPal`** (id=3234). PayPal is treated as the merchant of last resort.
+- Incoming transfers from PayPal to Fineco ("INSTANT TRANSFER", "Bonifico SEPA Estero ... Banca ordinante: PayPal") come from the **revenue account `PayPal Payout`** (id=4413).
+- The LunchFlow PayPal connection was permanently removed; no PayPal-side transactions are imported.
+
+The rules currently encoding this:
+- **Rule 428** `[passthrough] PayPal SDD (no merchant) → expense:PayPal` — triggers on `description_contains=LU96ZZZ0000000000000000058`, sets destination=`PayPal` expense, stops processing.
+- **Rule 429** `[income] PayPal Payout (INSTANT TRANSFER / SEPA Estero)` — triggers on transaction_type=Deposit + `description_contains=PayPal (Europe)`, sets source=`PayPal Payout`, category=`trasferimenti personali`.
+- Merchant-specific PayPal rules (e.g. `description_contains=Paypal *cloudflare` → Cloudflare, `Paypal *enelenergia` → Enel Energia, `Paypal *tradeinnret` → Tradeinn, etc.) remain active — they fire *before* the generic SDD catch and resolve the real merchant when the description carries it.
+
+The remaining PayPal-named entities are all either merchant buckets or routing helpers, never asset:
+
+| id | type | name | purpose |
+|---|---|---|---|
+| 3234 | expense | `PayPal` | Generic destination when no merchant is recoverable from the bank line. |
+| 3802 | expense | `PayPal Paga in 3` | Bucket for the user's PayPal BNPL splits. |
+| 4337 | expense | `PayPal Fee` | PayPal system fees. |
+| 4250 | expense | `Enrico (PayPal)` | A personal payee whose name keeps the PayPal hint. |
+| 4413 | revenue | `PayPal Payout` | Source for incoming PayPal payouts to Fineco. |
+
+Do not recreate the PayPal asset. Do not write rules whose action is `set_destination_account=PayPal` or `set_source_account=PayPal` expecting an asset to absorb the funds — those resolve to the expense bucket above, which is correct.
+
+## 5. Revolut funding and the topup convention
+
+Revolut is topped up by Fineco (debit *or* credit card via Apple Pay). In Firefly that's always a **transfer** between assets — `fineco → revolut` — not a withdrawal to an expense.
+
+A previous bug recorded 31 topups as withdrawals to a `"Revolut"` expense account, deeply skewing the revolut asset balance. That's resolved: topups are now transfers, the residual expense was renamed to **`Revolut (misc P2P/Ramp)` (id=3237)** and holds 9 real outflows for Revolut Ramp crypto purchases and peer-to-peer transfers to individual people — those still need per-person re-categorisation manually.
+
+Going forward, rule 21 (`[transfer] Revolut Top-Up (Fineco → Revolut)`) handles Fineco-sourced top-ups.
+
+## 6. Account taxonomy
+
+| Firefly type | Used for | Count today | Convention |
+|---|---|---:|---|
+| asset | Real money holders | 6 | One per bank wallet/card; multi-currency only if the wallet is actually used. |
+| liability | Real debts | 1 | Currently only Findomestic. |
+| revenue | Income sources | ~8 | Salary (Jakala), family transfers (Papà → Mediobanca), AECOM, Revolut Crypto sales, `PayPal Payout`, etc. |
+| expense | Merchants | ~540 | One canonical entry per real-world merchant. Bank-statement-style descriptors and `PAYPAL *xxx` variants get merged into the canonical merchant, not kept as separate accounts. |
+| cash | Firefly built-in "Cash account" | 1 | Reserved for *physical* cash (ATM withdrawals) and as Firefly's "unidentified counterparty" bucket. **Should be small.** If it grows, the importer or a rule is failing to attribute a real source — fix that, don't normalize Cash-as-merchant. |
+
+Merchant naming conventions:
+- Canonical merchants have short, human names: `Glovo`, `Amazon`, `A2A Energia`, `Trenitalia`, `ILIAD`, `Apple Services`, `Telepass`, `Decathlon`, `Affitto` (rent).
+- Bank descriptions like `"DECATHLON ITALIA srl U Lissone IT"` or `"Glovo 19apr Lufp4yu1"` are *not* canonical — they're statement noise that should resolve into the canonical merchant via a rule.
+- Personal payees keep readable names (e.g. `Marco Ninfa`, `Alessandro Siviero`, `Luca Faggio`). Avoid the `PAYPAL *` prefix on these — that prefix is statement noise, not part of the person's identity.
+
+## 7. Categories (the 28 buckets)
+
+```
+affitto · applications · bar & restaurants · car · cash · cloud ·
+commissioni · credito · crypto · delivery · drinks · events ·
+internet · papà · pharma & docs · rimborsi · salute · satispay ·
+shopping · spesa · sport · stipendi · tabacchi · taxi · transfer ·
+transport · trasferimenti personali · utenze
+```
+
+Conventions:
+- Italian for groceries (`spesa`), bills (`utenze`), rent (`affitto`), bank fees (`commissioni`), salary (`stipendi`).
+- Internal transfers between own assets get category `transfer` (or `trasferimenti personali` for transfers involving external bridges like the PayPal Payout flow).
+- `papà` is family income from the user's father.
+- `rimborsi` is reimbursements.
+
+## 8. Rules and bills
+
+**Rule groups (23):** organized by purpose — `Merchants`, `Default rules`, `Income`, `Expense accounts`, `System`, `subscriptions`, `Categories` (catchall), `Revenues`, plus 15 merchant subgroups by category (Bar & Restaurants, Grocery, Shopping, Transport, Fuel, Utilities, Health, Sport, Events, Apps, Cloud, Tabacco, Drinks, Delivery, Credit).
+
+**Bills (4 active):**
+- `Rent` — quarterly MAV (Italian payment slip). Bank description starts `"MAV nr. 03069 …"`; rule 34 (`[sub] Rent (MAV)`) links it to the bill *and* sets `category=affitto`.
+- `ILIAD` — monthly mobile.
+- `GitHub Org` — monthly.
+- `GitHub Copilot` — monthly. Triggered by `description_contains=Github`.
+
+**System rules covering Revolut and PayPal passthroughs:**
+- Rule 21 — `[transfer] Revolut Top-Up (Fineco → Revolut)` (Fineco-sourced top-ups become transfers, not withdrawals).
+- Rule 428 — `[passthrough] PayPal SDD (no merchant) → expense:PayPal` (Fineco SDD with mandate `LU96ZZZ0000000000000000058`).
+- Rule 429 — `[income] PayPal Payout (INSTANT TRANSFER / SEPA Estero)` (Deposit + `PayPal (Europe)` → revenue `PayPal Payout` + category `trasferimenti personali`).
+- Rule 430 — `[crypto] Revolut Ramp → expense:Revolut Ramp + category:crypto`.
+- Rule 431 — `[transfer] Revolut P2P (Inviato da Revolut) → category:trasferimenti personali` (no destination override — Firefly auto-creates a per-recipient expense from the description, which *is* the desired per-person split).
+
+## 9. Hard invariants (don't violate these — or things break in subtle ways)
+
+1. **Native Firefly Reconciliation transactions only.** Never create a fake withdrawal/deposit (or move money to/from "Cash account") to make a balance line up. Firefly's `reconciliation` transaction type is first-class and excluded from spending reports; placeholder journals pollute everything.
+2. **Bank statement descriptions are not merchants.** The importer creates an expense account with the full description when no rule matches. Those auto-merchants are noise — every cleanup pass should fold them back into the canonical merchant.
+3. **Don't trust the Carta Credito Fineco balance.** Imports are sporadic. Use it for categorisation history, not as ground truth.
+4. **PayPal is not an asset, never was.** Don't recreate the PayPal asset account; don't treat PayPal as if it holds the user's money. PayPal-mediated transactions are either resolved into their real merchant (`Fineco → <Merchant>`) or, when the merchant is unrecoverable from the bank line, attributed to the `PayPal` expense bucket. Incoming PayPal payouts come from the `PayPal Payout` revenue.
+5. **"Cash account" is for unidentified or physical cash, nothing else.** If `Cash account → fineco` deposits start accumulating, the importer or a rule isn't catching a real source — fix it upstream, don't normalize the Cash-as-source pattern.
+6. **Merge before delete.** When pruning duplicate merchants, do the reassignment (variant tx → canonical) *before* deleting the variant. Otherwise the canonical (often `bal=0` and `last_activity=None`) gets caught by stale-cleanup filters.
+7. **Apply rules sparingly on bulk mutations.** When editing transactions programmatically (PUT `/transactions/{id}`), set `apply_rules: false, fire_webhooks: false`. Otherwise a bulk fix triggers thousands of rule re-evaluations.
+
+## 10. When to go to the operational skill
+
+For anything that requires *acting* — calling the API, running artisan commands, rotating the importer config, querying the DB, triggering autoimport, applying rules in bulk — load the **`firefly` skill** (sibling at `.claude/skills/firefly/SKILL.md`). That skill has the surfaces and the helper scripts. This one tells you what your action should *mean*.
+
+Always pair the two: read this skill to understand the user's model; read `firefly` to perform the work.

--- a/services/firefly/docker-compose.yml
+++ b/services/firefly/docker-compose.yml
@@ -291,7 +291,7 @@ services:
       <<: *logging-base
 
   scheduler:
-    image: alpine
+    image: python:3.13-alpine
     hostname: firefly-scheduler
     environment:
       - TZ=Europe/Rome
@@ -300,6 +300,7 @@ services:
       - firefly_access_token
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./scripts/cc_monthly_reconcile.py:/usr/local/bin/cc_monthly_reconcile.py:ro
     command: >
       sh -c "apk add --no-cache tzdata wget docker-cli &&
       ln -sf /usr/share/zoneinfo/Europe/Rome /etc/localtime &&
@@ -310,6 +311,7 @@ services:
       FIREFLY_ACCESS_TOKEN=\$$(cat /run/secrets/firefly_access_token) &&
       echo '0 6 * * * docker exec \$$(docker ps --filter "label=com.docker.swarm.service.name=firefly_app" --format "{{.Names}}") php artisan firefly-iii:cron' > /tmp/crontab &&
       echo '0 6 * * * wget -qO- --post-data=\"\" --header=\"Accept: application/json\" --header=\"Authorization: Bearer '$$FIREFLY_ACCESS_TOKEN'\" http://firefly-importer:8080/autoimport?directory=/var/www/html/import\\&secret='$$AUTO_IMPORT_SECRET >> /tmp/crontab &&
+      echo '0 4 11 * * python3 /usr/local/bin/cc_monthly_reconcile.py >> /proc/1/fd/1 2>&1' >> /tmp/crontab &&
       crontab /tmp/crontab &&
       rm /tmp/crontab &&
       echo 'Cron jobs configured:' &&

--- a/services/firefly/scripts/cc_monthly_reconcile.py
+++ b/services/firefly/scripts/cc_monthly_reconcile.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Pin Carta Credito Fineco (id 3848) to zero after each monthly ESTRATTO.
+
+Designed to run on the 11th of each month via cron inside the firefly_scheduler
+container. Idempotent and defensive:
+
+  1. Verify the most recent settlement transfer (fineco -> CC) is within the
+     last 14 days. If not, log + skip (LunchFlow gap or missing ESTRATTO —
+     don't blindly zero the account; surface the problem instead).
+  2. Read current CC balance.
+  3. If non-zero, post a native reconciliation transaction (source = paired
+     reconciliation account, destination = CC) bringing CC to 0, dated to the
+     settlement day. If already zero, do nothing.
+
+The reconciliation account is auto-discovered (Firefly creates one per asset
+on first reconciliation). All log output goes to stdout so `docker service
+logs firefly_scheduler` surfaces it.
+"""
+import json, os, subprocess, sys, urllib.error, urllib.request
+from datetime import datetime, timedelta, timezone
+
+CC_ID            = 3848
+RECON_ACCT_HINT  = 4421
+SETTLEMENT_WINDOW_DAYS = 14
+APP_URL          = "http://firefly-app:8080"
+TOKEN_PATH       = "/run/secrets/firefly_access_token"
+
+def log(msg):
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[cc_monthly_reconcile {ts}] {msg}", flush=True)
+
+def load_token():
+    try:
+        with open(TOKEN_PATH) as f: return f.read().strip()
+    except OSError as e:
+        log(f"FATAL: cannot read token at {TOKEN_PATH}: {e}"); sys.exit(2)
+
+def api(method, path, token, body=None):
+    url = f"{APP_URL}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/json")
+    if data is not None: req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status, json.loads(r.read().decode() or "null")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        try: parsed = json.loads(body)
+        except json.JSONDecodeError: parsed = body
+        return e.code, parsed
+    except urllib.error.URLError as e:
+        log(f"FATAL: network error calling {url}: {e}"); sys.exit(3)
+
+def find_recon_account(token):
+    """Return id of the reconciliation account paired with the CC asset."""
+    page = 1
+    while True:
+        st, d = api("GET", f"/api/v1/accounts?type=reconciliation&limit=50&page={page}", token)
+        if st != 200: return None
+        for a in d.get("data", []):
+            # the paired account shares the asset's name
+            if a["attributes"]["name"] == "Carta Credito Fineco":
+                return int(a["id"])
+        meta = (d.get("meta") or {}).get("pagination") or {}
+        if page >= meta.get("total_pages", 1): break
+        page += 1
+    return None
+
+def recent_settlement(token):
+    """Return (date_iso, amount, group_id) of the most recent fineco->CC
+    transfer in the last SETTLEMENT_WINDOW_DAYS days, or None."""
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=SETTLEMENT_WINDOW_DAYS)).date().isoformat()
+    today = datetime.now(timezone.utc).date().isoformat()
+    st, d = api("GET",
+                f"/api/v1/accounts/{CC_ID}/transactions?type=transfer&start={cutoff}&end={today}&limit=50",
+                token)
+    if st != 200: return None
+    candidates = []
+    for g in d.get("data", []):
+        for s in g["attributes"]["transactions"]:
+            if str(s["source_id"]) == "1" and str(s["destination_id"]) == str(CC_ID):
+                candidates.append((s["date"][:10], float(s["amount"]), g["id"], s.get("description") or ""))
+    if not candidates: return None
+    candidates.sort(reverse=True)
+    return candidates[0]
+
+def main():
+    token = load_token()
+
+    log("checking most recent ESTRATTO settlement...")
+    recent = recent_settlement(token)
+    if recent is None:
+        log(f"SKIP: no fineco->CC transfer found in last {SETTLEMENT_WINDOW_DAYS} days. "
+            f"Either LunchFlow is lagging, rule 9 misfired, or there was no ESTRATTO this cycle. "
+            f"Investigate before reconciling.")
+        return
+    settle_date, settle_amount, settle_gid, settle_desc = recent
+    log(f"found settlement: date={settle_date} amount=€{settle_amount:.2f} group={settle_gid}")
+    log(f"  desc: {settle_desc[:100]}")
+
+    log("reading CC balance...")
+    st, d = api("GET", f"/api/v1/accounts/{CC_ID}", token)
+    if st != 200:
+        log(f"FATAL: GET /accounts/{CC_ID} returned {st}"); sys.exit(4)
+    cc_balance = float(d["data"]["attributes"]["current_balance"])
+    log(f"CC balance = {cc_balance:+.2f}")
+
+    if abs(cc_balance) < 0.01:
+        log("balance already at 0 — nothing to do (idempotent)")
+        return
+
+    amount = -cc_balance  # +ve to bring negative balance up to 0
+    log(f"reconciliation amount = {amount:.2f} EUR")
+
+    recon_id = find_recon_account(token)
+    if recon_id is None:
+        log(f"reconciliation account not found by name; falling back to hint id={RECON_ACCT_HINT}")
+        recon_id = RECON_ACCT_HINT
+    log(f"reconciliation account id = {recon_id}")
+
+    if amount > 0:
+        source_id, dest_id = recon_id, CC_ID
+    else:
+        source_id, dest_id = CC_ID, recon_id
+        amount = -amount
+
+    log(f"posting reconciliation: source={source_id} dest={dest_id} amount={amount:.2f} dated={settle_date}")
+    body = {
+        "transactions": [{
+            "type": "reconciliation",
+            "date": f"{settle_date}T12:00:00+02:00",
+            "amount": f"{amount:.2f}",
+            "currency_code": "EUR",
+            "source_id": str(source_id),
+            "destination_id": str(dest_id),
+            "description": f"Auto-reconciliation post-ESTRATTO {settle_date} — pin Carta Credito Fineco to 0 (paid in full)",
+            "notes": f"Triggered by monthly cron after detecting settlement group {settle_gid} of €{settle_amount:.2f}. Adjusts for any unimported CC purchases from prior cycles."
+        }],
+        "apply_rules": False,
+        "fire_webhooks": False,
+        "error_if_duplicate_hash": True
+    }
+    st, resp = api("POST", "/api/v1/transactions", token, body)
+    if st in (200, 201):
+        gid = resp["data"]["id"]
+        s = resp["data"]["attributes"]["transactions"][0]
+        log(f"OK: reconciliation group={gid} CC balance now {s.get('destination_balance_after') or s.get('source_balance_after')}")
+    else:
+        log(f"FAIL: POST returned {st}; response={json.dumps(resp)[:400]}")
+        sys.exit(5)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `services/firefly/scripts/cc_monthly_reconcile.py` and a `0 4 11 * *` cron entry in `firefly_scheduler` that pins **Carta Credito Fineco** to 0 after each ESTRATTO CONTO via Firefly's native reconciliation transaction
- Switches `firefly_scheduler` base image from `alpine` to `python:3.13-alpine` so python3 is built-in (only tzdata/wget/docker-cli installed via apk)
- Adds the `firefly-logic` domain-model skill describing the CC mental model, rule 9's role as ESTRATTO router, and the reconciliation invariants

## Why
LunchFlow sees Fineco completely but cannot see intra-cycle CC purchases — those come in via sporadic CSV uploads. Without intervention the CC balance drifts negative between imports, accumulated up to **−€17,403.51** before this fix. The CC bank balance ≈ 0 right after each monthly ESTRATTO (the user pays in full), so we use that known checkpoint to keep Firefly aligned automatically. Native reconciliation transactions are excluded from spending reports; no `opening_balance` edits, no placeholder journals.

The script is defensive: skips with a logged alert if no `fineco → CC` transfer landed in the last 14 days (LunchFlow gap or rule misfire — surface rather than mask).

## Already applied to the live instance (out-of-band, today)
- Restored rule 9 to `convert_transfer='Carta Credito Fineco'` (had silently lost the conversion action; 3 ESTRATTOs since April were landing on a phantom expense)
- Repointed transactions 8336, 8220 (real ESTRATTOs) and 8259 (one stray debit-card purchase → new expense `10 Gradi Nord`)
- Deleted phantom expense `Carta Credito Fineco` (id 4361)
- Posted one-time reconciliation dated 2026-05-10, **CC balance now 0.00**

## Test plan
- [ ] Portainer auto-deploys the firefly stack from main after merge
- [ ] `docker service ps firefly_scheduler` shows the service Running on the new `python:3.13-alpine` image
- [ ] `docker service logs firefly_scheduler --tail 50` includes the 3 cron entries (artisan / autoimport / cc_monthly_reconcile)
- [ ] On next 11th (2026-06-11 04:00 Europe/Rome), the cron fires; logs show either "balance already at 0 — nothing to do" (if no CSVs imported since the May reconciliation) or a reconciliation posted dated 2026-06-10 with the expected amount
- [ ] Reconciliation appears at `https://firefly.giocaizzi.xyz/transactions/show/<id>` with type=reconciliation; CC asset balance shows 0; reports/charts unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)