### PR TITLE
refactor(firefly): use opening_balance edits for drift correction

### DIFF
--- a/.claude/skills/firefly-logic/SKILL.md
+++ b/.claude/skills/firefly-logic/SKILL.md
@@ -33,7 +33,34 @@ Cards in active use:
 | **Manual CSV** (`services/firefly/config/conifg_credit.json`) | `Carta Credito Fineco` | Categorisation only — imports are sporadic ("when I remember"). **Balance is never authoritative.** |
 | **Manual entry / UI** | Anything | Used to fill gaps and to fix one-off mismatches. |
 
-**Implication:** when somebody (you, the user) asks "what's my balance on X?" — trust the Fineco/Revolut LunchFlow-fed accounts and hedge on the credit card.
+**Stationary-balance invariant:** every asset balance must match the bank app at any point in time. When that breaks, **adjust the account's `opening_balance` field** (one PUT on the genesis journal) — do not insert reconciliation transactions, do not create placeholder withdrawals/deposits, do not use a `Cash account` plug.
+
+LunchFlow may occasionally miss a transaction (small purchases, intermittent connection); over months that drifts. If you notice Firefly diverging from the bank app, edit the opening_balance to absorb the gap.
+
+## 2a. Drift correction via opening_balance — the only mechanism
+
+This applies to **every asset** (fineco, revolut, CC, USD/GBP wallets). One pattern, no exceptions:
+
+```
+new_opening = current_opening - (current_balance - target_balance)
+```
+
+- `target_balance` = whatever the bank app currently says (for CC: 0 right after each ESTRATTO).
+- `current_opening` = the asset's current `opening_balance` field.
+- API: `PUT /api/v1/accounts/{id}` with `{ "opening_balance": "<new>", "opening_balance_date": "<unchanged>" }`. Edits the existing system-generated genesis journal in place.
+
+**Why this and not reconciliation transactions:**
+- No synthetic-looking journals appear in the ledger.
+- No paired reconciliation accounts to recreate or manage.
+- One mechanism, applied identically for the one-time historical drift cleanup and the ongoing CC monthly pin.
+
+**What you give up:** a per-correction journal as audit trail. The audit trail instead lives in `docker service logs firefly_scheduler` for the CC cron, and in this skill / project memory for one-off edits.
+
+**Trigger pattern by account:**
+- `fineco`, `revolut`: manual when divergence noticed (no fixed schedule — these are continuously variable).
+- `Carta Credito Fineco`: automatic on the 11th of every month via the cron in §3 (real CC balance ≈ 0 right after each ESTRATTO is the known checkpoint).
+
+Don't try to find the missing/extra transactions to reverse one-by-one — drift accumulates from hundreds of tiny gaps over years and chasing each costs more than it's worth. The opening_balance edit re-establishes a known-good point and you carry on.
 
 ## 3. The credit card mental model
 
@@ -68,21 +95,18 @@ If this rule loses the `convert_transfer` action, the importer silently creates 
 
 Settlements arrive continuously and completely via LunchFlow. Purchases arrive sporadically via manual CSV. **The CC balance in Firefly lags reality between CSV imports** — that's the cost of not running a full PSD2 feed on the card. Chasing per-transaction completeness is not the goal.
 
-### Auto-reconciliation: pin to 0 on the 11th of each month
+### Auto-pin to 0 on the 11th of each month
 
-A cron job in `firefly_scheduler` runs on the **11th at 04:00** (one day after each ESTRATTO) and posts a native Firefly **reconciliation transaction** that brings the CC balance to exactly 0:
+A cron job in `firefly_scheduler` runs on the **11th at 04:00** (one day after each ESTRATTO) and **adjusts `opening_balance`** so current_balance collapses to exactly 0:
 
 - Script: `services/firefly/scripts/cc_monthly_reconcile.py`.
+- Mechanism: `PUT /accounts/3848` with `opening_balance = current_opening - current_balance`. No new journals are created; the existing system genesis journal is edited in place. Consistent with §2a.
 - Defensive: only fires if a `fineco → CC` transfer occurred within the last 14 days. If LunchFlow lagged or the ESTRATTO never arrived, the job logs and skips instead of blindly zeroing.
 - Idempotent: if the balance is already 0, it does nothing.
-- Native reconciliation = excluded from spending reports / charts / category totals; the paired reconciliation account (auto-created by Firefly) absorbs the offsetting side and is excluded from net worth.
-- Reconciliation direction: `source = reconciliation account, destination = CC, amount = -balance` (positive amount brings a negative CC balance up toward 0).
 
-This means right after each settlement the CC balance shows the truth (0 = paid in full). As you upload CSVs through the next cycle, the balance drifts negative — that's "what I've categorised this cycle so far", not the real bank balance. On the next 11th, the cron re-pins to 0.
+This means right after each settlement the CC balance shows the truth (0 = paid in full). As you upload CSVs through the next cycle, the balance drifts negative — that's "what I've categorised this cycle so far", not the real bank balance. On the next 11th, the cron re-pins to 0 by shifting opening_balance.
 
-### Never edit `opening_balance` to mask drift
-
-`opening_balance` represents the real CC owed amount the day Firefly started tracking — nothing else. Editing it post-creation silently rewrites the genesis journal with no audit trail and violates the user's invariant on native reconciliation. If you find yourself wanting to nudge the opening balance, use a reconciliation transaction instead.
+The opening_balance therefore becomes a *rolling drift compensator* rather than a fixed historical starting amount. That's an unusual semantic, but mechanically simplest: one field, no reconciliation accounts to maintain, no journals to manage.
 
 ### Card-number heuristics
 
@@ -172,7 +196,7 @@ Conventions:
 
 ## 9. Hard invariants (don't violate these — or things break in subtle ways)
 
-1. **Native Firefly Reconciliation transactions only.** Never create a fake withdrawal/deposit (or move money to/from "Cash account") to make a balance line up. Firefly's `reconciliation` transaction type is first-class and excluded from spending reports; placeholder journals pollute everything.
+1. **Drift correction = `opening_balance` edit.** Never create reconciliation transactions, fake withdrawals/deposits, or `Cash account` plugs to align a balance. Adjust the asset's `opening_balance` field (see §2a). One mechanism, applied uniformly.
 2. **Bank statement descriptions are not merchants.** The importer creates an expense account with the full description when no rule matches. Those auto-merchants are noise — every cleanup pass should fold them back into the canonical merchant.
 3. **Don't trust the Carta Credito Fineco balance.** Imports are sporadic. Use it for categorisation history, not as ground truth.
 4. **PayPal is not an asset, never was.** Don't recreate the PayPal asset account; don't treat PayPal as if it holds the user's money. PayPal-mediated transactions are either resolved into their real merchant (`Fineco → <Merchant>`) or, when the merchant is unrecoverable from the bank line, attributed to the `PayPal` expense bucket. Incoming PayPal payouts come from the `PayPal Payout` revenue.

--- a/services/firefly/scripts/cc_monthly_reconcile.py
+++ b/services/firefly/scripts/cc_monthly_reconcile.py
@@ -2,28 +2,32 @@
 """Pin Carta Credito Fineco (id 3848) to zero after each monthly ESTRATTO.
 
 Designed to run on the 11th of each month via cron inside the firefly_scheduler
-container. Idempotent and defensive:
+container. Idempotent and defensive.
 
+Mechanism: adjusts the account's `opening_balance` so that current_balance
+collapses to zero. No reconciliation/balancing journals are created; the
+single system-generated opening-balance journal is edited in place. This
+keeps the ledger free of synthetic transactions and avoids maintaining a
+paired reconciliation account.
+
+Flow:
   1. Verify the most recent settlement transfer (fineco -> CC) is within the
      last 14 days. If not, log + skip (LunchFlow gap or missing ESTRATTO —
      don't blindly zero the account; surface the problem instead).
   2. Read current CC balance.
-  3. If non-zero, post a native reconciliation transaction (source = paired
-     reconciliation account, destination = CC) bringing CC to 0, dated to the
-     settlement day. If already zero, do nothing.
+  3. If non-zero, PUT a new opening_balance = current_opening - current_balance.
+     This shifts opening_balance so current_balance becomes zero.
 
-The reconciliation account is auto-discovered (Firefly creates one per asset
-on first reconciliation). All log output goes to stdout so `docker service
-logs firefly_scheduler` surfaces it.
+All log output goes to stdout so `docker service logs firefly_scheduler`
+surfaces it.
 """
 import json, os, subprocess, sys, urllib.error, urllib.request
 from datetime import datetime, timedelta, timezone
 
-CC_ID            = 3848
-RECON_ACCT_HINT  = 4421
+CC_ID                  = 3848
 SETTLEMENT_WINDOW_DAYS = 14
-APP_URL          = "http://firefly-app:8080"
-TOKEN_PATH       = "/run/secrets/firefly_access_token"
+APP_URL                = "http://firefly-app:8080"
+TOKEN_PATH             = "/run/secrets/firefly_access_token"
 
 def log(msg):
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -53,23 +57,8 @@ def api(method, path, token, body=None):
     except urllib.error.URLError as e:
         log(f"FATAL: network error calling {url}: {e}"); sys.exit(3)
 
-def find_recon_account(token):
-    """Return id of the reconciliation account paired with the CC asset."""
-    page = 1
-    while True:
-        st, d = api("GET", f"/api/v1/accounts?type=reconciliation&limit=50&page={page}", token)
-        if st != 200: return None
-        for a in d.get("data", []):
-            # the paired account shares the asset's name
-            if a["attributes"]["name"] == "Carta Credito Fineco":
-                return int(a["id"])
-        meta = (d.get("meta") or {}).get("pagination") or {}
-        if page >= meta.get("total_pages", 1): break
-        page += 1
-    return None
-
 def recent_settlement(token):
-    """Return (date_iso, amount, group_id) of the most recent fineco->CC
+    """Return (date_iso, amount, group_id, desc) of the most recent fineco->CC
     transfer in the last SETTLEMENT_WINDOW_DAYS days, or None."""
     cutoff = (datetime.now(timezone.utc) - timedelta(days=SETTLEMENT_WINDOW_DAYS)).date().isoformat()
     today = datetime.now(timezone.utc).date().isoformat()
@@ -100,56 +89,37 @@ def main():
     log(f"found settlement: date={settle_date} amount=€{settle_amount:.2f} group={settle_gid}")
     log(f"  desc: {settle_desc[:100]}")
 
-    log("reading CC balance...")
+    log("reading CC account state...")
     st, d = api("GET", f"/api/v1/accounts/{CC_ID}", token)
     if st != 200:
         log(f"FATAL: GET /accounts/{CC_ID} returned {st}"); sys.exit(4)
-    cc_balance = float(d["data"]["attributes"]["current_balance"])
-    log(f"CC balance = {cc_balance:+.2f}")
+    a = d["data"]["attributes"]
+    cur_bal = float(a["current_balance"])
+    cur_opening = float(a["opening_balance"] or 0)
+    opening_date = a["opening_balance_date"]
+    log(f"current_balance = {cur_bal:+.2f}  opening_balance = {cur_opening:+.2f}  (dated {opening_date[:10] if opening_date else 'n/a'})")
 
-    if abs(cc_balance) < 0.01:
+    if abs(cur_bal) < 0.01:
         log("balance already at 0 — nothing to do (idempotent)")
         return
 
-    amount = -cc_balance  # +ve to bring negative balance up to 0
-    log(f"reconciliation amount = {amount:.2f} EUR")
+    new_opening = cur_opening - cur_bal
+    log(f"adjusting opening_balance: {cur_opening:+.2f} -> {new_opening:+.2f}  (delta {-cur_bal:+.2f})")
 
-    recon_id = find_recon_account(token)
-    if recon_id is None:
-        log(f"reconciliation account not found by name; falling back to hint id={RECON_ACCT_HINT}")
-        recon_id = RECON_ACCT_HINT
-    log(f"reconciliation account id = {recon_id}")
-
-    if amount > 0:
-        source_id, dest_id = recon_id, CC_ID
-    else:
-        source_id, dest_id = CC_ID, recon_id
-        amount = -amount
-
-    log(f"posting reconciliation: source={source_id} dest={dest_id} amount={amount:.2f} dated={settle_date}")
-    body = {
-        "transactions": [{
-            "type": "reconciliation",
-            "date": f"{settle_date}T12:00:00+02:00",
-            "amount": f"{amount:.2f}",
-            "currency_code": "EUR",
-            "source_id": str(source_id),
-            "destination_id": str(dest_id),
-            "description": f"Auto-reconciliation post-ESTRATTO {settle_date} — pin Carta Credito Fineco to 0 (paid in full)",
-            "notes": f"Triggered by monthly cron after detecting settlement group {settle_gid} of €{settle_amount:.2f}. Adjusts for any unimported CC purchases from prior cycles."
-        }],
-        "apply_rules": False,
-        "fire_webhooks": False,
-        "error_if_duplicate_hash": True
-    }
-    st, resp = api("POST", "/api/v1/transactions", token, body)
-    if st in (200, 201):
-        gid = resp["data"]["id"]
-        s = resp["data"]["attributes"]["transactions"][0]
-        log(f"OK: reconciliation group={gid} CC balance now {s.get('destination_balance_after') or s.get('source_balance_after')}")
-    else:
-        log(f"FAIL: POST returned {st}; response={json.dumps(resp)[:400]}")
+    body = {"opening_balance": f"{new_opening:.2f}", "opening_balance_date": opening_date}
+    st, resp = api("PUT", f"/api/v1/accounts/{CC_ID}", token, body)
+    if st not in (200, 201):
+        log(f"FAIL: PUT returned {st}; response={json.dumps(resp)[:400]}")
         sys.exit(5)
+
+    # verify
+    st, d = api("GET", f"/api/v1/accounts/{CC_ID}", token)
+    new_cur = float(d["data"]["attributes"]["current_balance"])
+    if abs(new_cur) < 0.01:
+        log(f"OK: opening_balance updated; current_balance now {new_cur:+.2f}")
+    else:
+        log(f"WARN: opening_balance updated but current_balance={new_cur:+.2f} (expected 0); investigate")
+        sys.exit(6)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Rewrites `services/firefly/scripts/cc_monthly_reconcile.py` to use `PUT /accounts/3848 {opening_balance: ...}` instead of `POST /transactions {type: reconciliation}` for the monthly CC pin-to-zero
- Updates `firefly-logic` skill (§2a, §3, §9 invariant 1) to codify a single drift-correction mechanism

## Why
Reconciliation transactions look synthetic in the ledger (no real money movement) and require maintaining paired reconciliation accounts. Editing `opening_balance` edits the existing system-generated genesis journal in place — no new journals, no balancing accounts, no synthetic-looking entries.

The same mechanism is now used for both the one-time historical drift cleanup (already applied live to fineco, revolut, CC opening balances) and the ongoing monthly CC pin. One pattern, applied uniformly.

## Test plan
- [ ] Portainer auto-redeploys firefly stack from main after merge
- [ ] `docker service ps firefly_scheduler` shows service Running (no compose changes — bind-mounted script picks up the new content automatically)
- [ ] On next 11th (2026-06-11 04:00 Europe/Rome), cron fires; logs show either "balance already at 0 — nothing to do" or a PUT to `/accounts/3848` adjusting opening_balance and verifying current_balance = 0
- [ ] No new reconciliation accounts appear in `/api/v1/accounts?type=reconciliation` (should remain 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)