### PR TITLE
feat(firefly): swap core image to ghcr.io/giocaizzi/firefly-iii:mcp

### DIFF
--- a/services/firefly/docker-compose.yml
+++ b/services/firefly/docker-compose.yml
@@ -51,7 +51,7 @@ networks:
 # =============================================================================
 services:
   app:
-    image: fireflyiii/core:latest
+    image: ghcr.io/giocaizzi/firefly-iii:mcp
     hostname: firefly-app
     expose:
       - "8080"


### PR DESCRIPTION
## Summary

Swaps the `app` service in the Firefly stack from upstream `fireflyiii/core:latest` to my custom build `ghcr.io/giocaizzi/firefly-iii:mcp`, which adds the **Model Context Protocol** endpoint at `/api/v1/mcp` for agentic AI access.

- New endpoint exposes 25 tools (10 read-core, 1 search, 4 power-user, 4 aggregates, 6 writes) + 8 resources (4 static catalogs + 4 user snapshots) to MCP clients.
- Auth reuses existing Personal Access Tokens (Bearer header), no new OAuth surface.
- Gated behind the `allow_mcp` instance flag, default ON.
- Cross-currency transfers explicitly NOT supported (use the web UI for those).
- `data-importer` stays on upstream `:latest` — MCP lives in core only.

## Image provenance

- Source branch: [`giocaizzi/firefly-iii:feat/mcp-integration`](https://github.com/giocaizzi/firefly-iii/tree/feat/mcp-integration) (32 commits ahead of upstream `v6.6.2`)
- Build strategy: overlay on `fireflyiii/core:latest` (no full source rebuild)
- Platform: `linux/arm64` (pinned for the Pi 5)
- Digest: `sha256:9b653f23eda8a7d6...`
- Built with: `docker buildx build --platform linux/arm64 -t ghcr.io/giocaizzi/firefly-iii:mcp -f Dockerfile.mcp --push .`

## How to drive the endpoint

A Claude Code plugin lives at [giocaizzi/claude-plugins](https://github.com/giocaizzi/claude-plugins) (firefly-mcp) — installs the MCP server registration + a skill that teaches Claude when and how to call the tools, plus four slash commands and a categorization agent.

## Test plan

- [ ] Pull updated stack on the swarm host: `docker stack deploy -c services/firefly/docker-compose.yml firefly`
- [ ] Verify the `firefly_app` task lands the new image: `docker service ps firefly_app | head -3`
- [ ] Health check still passes: `curl -sk https://<firefly-url>/health || curl -sk http://localhost:8080$HEALTHCHECK_PATH`
- [ ] Confirm MCP handshake from outside the swarm:
  ```bash
  curl -sS https://<firefly-url>/api/v1/mcp \
    -H "Authorization: Bearer $FIREFLY_PAT" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
  ```
  Expect `result.serverInfo.name = "Firefly III MCP"`.
- [ ] Existing REST API endpoints unchanged (regression check): `/api/v1/about`, `/api/v1/accounts`.
- [ ] Web UI still reachable.
- [ ] If anything regresses, roll back by reverting this commit and redeploying.

## Rollback

```
git revert <this-merge-commit>
git push
docker stack deploy -c services/firefly/docker-compose.yml firefly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)