### PR TITLE
fix(observability): pin tempo to 2.10.5

### DIFF
--- a/services/observability/docker-compose.yml
+++ b/services/observability/docker-compose.yml
@@ -160,7 +160,7 @@ services:
   # Receives traces ONLY from Alloy via OTLP gRPC.
   # All external trace ingestion goes through Alloy for processing.
   trace-store:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.10.5
     hostname: observability-trace-store
     expose:
       - "3200"  # Tempo HTTP (queries)


### PR DESCRIPTION
## Summary

Shepherd auto-pulled `grafana/tempo:latest` to **v3.0.0-rc.1**, whose config schema removed `metrics_generator.traces_storage` and the `local_blocks` processor at their current YAML paths. Tempo crash-looped on:

```
failed parsing config: failed to parse configFile /etc/tempo/tempo-config.yaml: yaml: unmarshal errors:
  line 59: field traces_storage not found in type generator.Config
  line 64: field local_blocks not found in type generator.ProcessorConfig
```

Swarm gave up after `max_attempts: 3` and the service has been stuck at `0/1` for ~2 days.

Pinning to the latest stable v2 (`2.10.5`, released 2026-04-23) keeps the existing `tempo-config.yaml` valid and stops Shepherd's drift on this image.

## Follow-ups (not in this PR)

- Same `:latest` pattern across all 5 observability images and most of the other stacks — Loki, Prometheus, Alloy, Grafana, etc. Same Shepherd-drift risk. Worth a sweep to pin majors.
- Tempo v3 upgrade is a deliberate config migration; do it separately when ready.

## Test plan

- [ ] Merge → Portainer auto-redeploys observability with the pinned image.
- [ ] `docker service ps observability_trace-store` shows `Running 1/1`.
- [ ] Grafana → Explore → Tempo datasource → confirm queries work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)