### PR TITLE
fix(observability): split otel pipeline by signal; move defaults to resource

### DIFF
--- a/services/observability/alloy/pipelines/otel.alloy
+++ b/services/observability/alloy/pipelines/otel.alloy
@@ -1,11 +1,29 @@
 // =============================================================================
 // OTEL PIPELINE MODULE
 // =============================================================================
-// Receives telemetry via OTLP (HTTP/gRPC), processes with batching and
-// attribute injection, then exports to appropriate backends.
+// Receives telemetry via OTLP (HTTP/gRPC), applies resource-level defaults
+// for external clients, then fans out by signal to the appropriate backend.
 //
 // Data Flow:
-//   OTLP Receivers → Batch Processor → Attribute Processor → Backend Exporters
+//   OTLP Receivers → Batch → Resource Defaults → ┌─ metrics → Prometheus
+//                                                ├─ traces  → Tempo
+//                                                └─ logs    → Loki Hints → Loki
+//
+// Why split by signal:
+//   Loki uses magic "loki.resource.labels" / "loki.attribute.labels" hint
+//   attributes to choose which keys become indexed stream labels. Inserting
+//   them in a shared processor leaks them as labels onto Prometheus series
+//   (cardinality bloat) and as attributes on Tempo spans. They live only on
+//   the log path.
+//
+//   Resource-level metadata (service.namespace, deployment.environment.name,
+//   source, tier) must be applied via otelcol.processor.resource — not
+//   otelcol.processor.attributes — so they land on the Resource and not on
+//   every data point. The attributes processor would otherwise overwrite
+//   nothing on the resource (resource keeps the client's value) but inject
+//   the default into each metric/log/span attribute, producing two competing
+//   values for the same key (e.g. job="claude-code/claude-code" on the
+//   resource but service_namespace="external" on the data point).
 //
 // Auth:
 //   HTTP (port 4318) requires `Authorization: Bearer <token>`. Same enforcement
@@ -85,55 +103,64 @@ declare "otlp_receivers" {
     send_batch_size = 100
 
     output {
-      metrics = [otelcol.processor.attributes.default.input]
-      logs    = [otelcol.processor.attributes.default.input]
-      traces  = [otelcol.processor.attributes.default.input]
+      metrics = [otelcol.processor.resource.defaults.input]
+      logs    = [otelcol.processor.resource.defaults.input]
+      traces  = [otelcol.processor.resource.defaults.input]
     }
   }
 
   // ---------------------------------------------------------------------------
-  // ATTRIBUTES PROCESSOR
+  // RESOURCE-LEVEL DEFAULTS
   // ---------------------------------------------------------------------------
-  // Injects standard attributes into all telemetry
+  // Fills missing resource attributes for external OTLP clients that don't
+  // set them. `action = "insert"` preserves any value the client already sent
+  // (e.g. service.namespace=claude-code from Claude Code's resource attrs).
 
-  otelcol.processor.attributes "default" {
-    // Default namespace for external apps
-    action {
+  otelcol.processor.resource "defaults" {
+    attributes {
+      action = "insert"
       key    = "service.namespace"
       value  = "external"
-      action = "insert"
     }
-
-    // Default environment
-    action {
+    attributes {
+      action = "insert"
       key    = "deployment.environment.name"
       value  = "production"
-      action = "insert"
     }
-
-    // Source identifier
-    action {
+    attributes {
+      action = "insert"
       key    = "source"
       value  = "otel"
-      action = "insert"
     }
-
-    // Default tier
-    action {
+    attributes {
+      action = "insert"
       key    = "tier"
       value  = "core"
-      action = "insert"
     }
 
-    // Loki label hints - controls which attributes become indexed labels
-    // loki.resource.labels: promotes RESOURCE attributes (sent by app)
+    output {
+      metrics = [otelcol.exporter.prometheus.default.input]
+      logs    = [otelcol.processor.attributes.loki_hints.input]
+      traces  = [otelcol.exporter.otlp.tempo.input]
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // LOKI LABEL HINTS (log path only)
+  // ---------------------------------------------------------------------------
+  // The Loki exporter reads these magic attributes to decide which resource
+  // and log-record attributes to promote to indexed stream labels. Confined
+  // to the log path so they never appear on Prometheus series or Tempo spans.
+  //
+  // loki.resource.labels  - promotes RESOURCE attributes (set by client SDK)
+  // loki.attribute.labels - promotes LOG RECORD attributes
+
+  otelcol.processor.attributes "loki_hints" {
     action {
       key    = "loki.resource.labels"
-      value  = "service.name, service.namespace, deployment.environment.name, component"
+      value  = "service.name, service.namespace, deployment.environment.name, component, host.name"
       action = "insert"
     }
-
-    // loki.attribute.labels: promotes LOG RECORD attributes (inserted above)
     action {
       key    = "loki.attribute.labels"
       value  = "source, tier"
@@ -141,9 +168,7 @@ declare "otlp_receivers" {
     }
 
     output {
-      metrics = [otelcol.exporter.prometheus.default.input]
-      logs    = [otelcol.exporter.loki.default.input]
-      traces  = [otelcol.exporter.otlp.tempo.input]
+      logs = [otelcol.exporter.loki.default.input]
     }
   }
 


### PR DESCRIPTION
## Summary

The OTLP receiver pipeline had a single shared `otelcol.processor.attributes` block sitting between batch and the exporters — it was doing two jobs that conflict at the layer where they were applied:

- **Loki label hints leaked into Prometheus & Tempo.** `loki.resource.labels` and `loki.attribute.labels` are routing directives the loki exporter reads to choose which keys become indexed stream labels. They were being inserted on every signal, so on the metric path they showed up as labels on every Prometheus series (e.g. `claude_code_session_count_total{loki_resource_labels="service.name, service.namespace, ..."}`) and on the trace path they showed up as span attributes. Pure cardinality bloat with no consumer.

- **`service.namespace=external` default poisoned metric data points.** The defaults (`service.namespace`, `deployment.environment.name`, `source`, `tier`) were inserted with `action="insert"` on the attributes processor, which operates on data-point attributes — not on the resource. Claude Code sends `service.namespace=claude-code` on the resource, so `target_info` and `job` came out right (`job="claude-code/claude-code"`), but every individual series got an `service_namespace="external"` data-point attribute, leaving two competing values in the TSDB for the same logical key.

## Fix

Restructure the pipeline so each concern lives in the right processor at the right layer:

```
OTLP receivers
  → batch
    → otelcol.processor.resource "defaults"   (resource layer, all signals)
      ├─ metrics → prometheus exporter
      ├─ traces  → tempo exporter
      └─ logs    → otelcol.processor.attributes "loki_hints" → loki exporter
```

Resource-level defaults move to `otelcol.processor.resource` (correct layer for service/environment/tier metadata). Loki hints live in a dedicated attributes processor wired only into the log path. Also adds `host.name` to the Loki resource-label promotion list so per-machine slicing works as a proper stream label.

Validated with `alloy fmt` on the running collector (parses clean). Indentation matches the existing 2-space convention used by sibling `.alloy` files in `pipelines/`.

## Behavior change

After deploy, expect on `claude_code_*` series in Prometheus:
- ❌ `loki_resource_labels`, `loki_attribute_labels` labels — **gone**
- ❌ `service_namespace="external"`, `source="otel"`, `tier="core"`, `deployment_environment_name="production"` labels — **gone from data points** (still present on `target_info` for joining)
- ✅ `job="claude-code/claude-code"` — unchanged
- ✅ `host_name`, `host_arch`, `os_type`, `os_version`, `service_version` — still on `target_info`

If any dashboards filter `tier="core"` or `source="otel"` on metric series directly (not via `target_info` join), they'll need to be updated. Loki streams gain a `host_name` label (so `{host_name="..."}` becomes a valid filter).

## Test plan

- [ ] PR merges → Portainer redeploys observability stack
- [ ] `docker service update --force observability_collector` to dodge the bind-mount inode trap (see `project_portainer_bind_mount_inode_trap.md`)
- [ ] Verify Alloy starts clean: `docker service logs observability_collector` no errors
- [ ] Verify metric label cleanup: `curl observability-metrics-store:9090/api/v1/series?match[]=claude_code_session_count_total` no longer contains `loki_*` labels
- [ ] Verify `host_name` is now a Loki stream label: `curl observability-log-store:3100/loki/api/v1/labels` includes `host_name`
- [ ] Verify Tempo spans still carry `host.name` resource attr (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)