### PR TITLE
fix(observability): use otelcol.processor.transform for resource defaults (fixes PR #133)

### DIFF
--- a/services/observability/alloy/pipelines/otel.alloy
+++ b/services/observability/alloy/pipelines/otel.alloy
@@ -103,9 +103,9 @@ declare "otlp_receivers" {
     send_batch_size = 100
 
     output {
-      metrics = [otelcol.processor.resource.defaults.input]
-      logs    = [otelcol.processor.resource.defaults.input]
-      traces  = [otelcol.processor.resource.defaults.input]
+      metrics = [otelcol.processor.transform.defaults.input]
+      logs    = [otelcol.processor.transform.defaults.input]
+      traces  = [otelcol.processor.transform.defaults.input]
     }
   }
 
@@ -113,29 +113,42 @@ declare "otlp_receivers" {
   // RESOURCE-LEVEL DEFAULTS
   // ---------------------------------------------------------------------------
   // Fills missing resource attributes for external OTLP clients that don't
-  // set them. `action = "insert"` preserves any value the client already sent
+  // set them. Uses otelcol.processor.transform with `context = "resource"` so
+  // statements run against resource attributes (not data-point attributes).
+  // The `where ... == nil` guard preserves any value the client already sent
   // (e.g. service.namespace=claude-code from Claude Code's resource attrs).
 
-  otelcol.processor.resource "defaults" {
-    attributes {
-      action = "insert"
-      key    = "service.namespace"
-      value  = "external"
+  otelcol.processor.transform "defaults" {
+    error_mode = "ignore"
+
+    metric_statements {
+      context = "resource"
+      statements = [
+        `set(resource.attributes["service.namespace"], "external") where resource.attributes["service.namespace"] == nil`,
+        `set(resource.attributes["deployment.environment.name"], "production") where resource.attributes["deployment.environment.name"] == nil`,
+        `set(resource.attributes["source"], "otel") where resource.attributes["source"] == nil`,
+        `set(resource.attributes["tier"], "core") where resource.attributes["tier"] == nil`,
+      ]
     }
-    attributes {
-      action = "insert"
-      key    = "deployment.environment.name"
-      value  = "production"
+
+    log_statements {
+      context = "resource"
+      statements = [
+        `set(resource.attributes["service.namespace"], "external") where resource.attributes["service.namespace"] == nil`,
+        `set(resource.attributes["deployment.environment.name"], "production") where resource.attributes["deployment.environment.name"] == nil`,
+        `set(resource.attributes["source"], "otel") where resource.attributes["source"] == nil`,
+        `set(resource.attributes["tier"], "core") where resource.attributes["tier"] == nil`,
+      ]
     }
-    attributes {
-      action = "insert"
-      key    = "source"
-      value  = "otel"
-    }
-    attributes {
-      action = "insert"
-      key    = "tier"
-      value  = "core"
+
+    trace_statements {
+      context = "resource"
+      statements = [
+        `set(resource.attributes["service.namespace"], "external") where resource.attributes["service.namespace"] == nil`,
+        `set(resource.attributes["deployment.environment.name"], "production") where resource.attributes["deployment.environment.name"] == nil`,
+        `set(resource.attributes["source"], "otel") where resource.attributes["source"] == nil`,
+        `set(resource.attributes["tier"], "core") where resource.attributes["tier"] == nil`,
+      ]
     }
 
     output {


### PR DESCRIPTION
## Summary

PR #133 referenced `otelcol.processor.resource` — a component that **does not exist in Grafana Alloy**. The Alloy distribution ships `otelcol.processor.resourcedetection` (only auto-detects host info) and `otelcol.processor.transform` (general OTTL processor), but not a plain `otelcol.processor.resource`. The merged change crashed the collector on startup:

```
Error: cannot find the definition of component name "otelcol.processor.resource"
```

Swarm cycled the task 4 times, hit the restart-policy ceiling, and paused the update — leaving `observability_collector` in `update paused` with no running tasks.

## Fix

Replace the resource block with `otelcol.processor.transform` configured with `context = "resource"` and four insert-if-missing OTTL statements. Same logical behavior as PR #133 intended; uses a component that's actually compiled into Alloy.

```alloy
otelcol.processor.transform "defaults" {
  error_mode = "ignore"

  metric_statements {
    context = "resource"
    statements = [
      `set(resource.attributes["service.namespace"], "external") where resource.attributes["service.namespace"] == nil`,
      `set(resource.attributes["deployment.environment.name"], "production") where resource.attributes["deployment.environment.name"] == nil`,
      `set(resource.attributes["source"], "otel") where resource.attributes["source"] == nil`,
      `set(resource.attributes["tier"], "core") where resource.attributes["tier"] == nil`,
    ]
  }
  // … same statements repeated for log_statements / trace_statements
}
```

OTTL paths use the explicit `resource.attributes["…"]` prefix instead of bare `attributes["…"]` — the transform processor emits a deprecation warning under a resource context when paths lack the prefix (it auto-rewrites them at startup).

## Validation

Ran `alloy validate` and a smoke `alloy run` against the v1.16.1 binary on the deployment target before pushing:

```
$ docker run --rm -v /tmp/alloy-validate:/etc/alloy:ro grafana/alloy:latest validate /etc/alloy/config.alloy
$ echo $?
0
```

Smoke `alloy run` reached steady state with no rewrite warnings, no schema errors, and the transform processor evaluating cleanly. The only error in the smoke-run logs was the expected missing `/run/secrets/alloy_otel_bearer_token` (only present in Swarm).

## Test plan

- [ ] Merge PR
- [ ] Wait for Portainer to re-clone main into `/mnt/portainer-compose-unpacker/stacks/observability/`
- [ ] `docker service update --force observability_collector` — required to (a) un-pause the failed update and (b) re-bind the inode-trapped mount
- [ ] Confirm task is `Running` and not in a restart loop
- [ ] Verify cleanup actually landed: query Prometheus for `claude_code_*` series — `loki_resource_labels` / `loki_attribute_labels` / `service_namespace="external"` labels should be gone
- [ ] Verify Loki now exposes `host_name` as a stream label

🤖 Generated with [Claude Code](https://claude.com/claude-code)