### PR TITLE
chore(homepage): point grafana and greenhouse to giocaizzi.xyz

### DIFF
--- a/infra/homepage/services.yaml
+++ b/infra/homepage/services.yaml
@@ -106,14 +106,14 @@
 
 - Home:
       - Greenhouse:
-            href: http://greenhouse.home
+            href: https://greenhouse.{{HOMEPAGE_FILE_DOMAIN}}
             description: Smart plant irrigation
             icon: mdi-sprout-#22c55e
             ping: http://greenhouse_app:8000/api/v1/clusters
 
 - Observability:
       - Grafana:
-            href: https://grafana.home
+            href: https://grafana.{{HOMEPAGE_FILE_DOMAIN}}
             description: Metrics and logs visualization
             icon: grafana.png
             ping: http://observability_dashboard:3000


### PR DESCRIPTION
## Summary
- Switch the homepage dashboard `href` for Grafana and Greenhouse to the public hostname template (`https://<svc>.{{HOMEPAGE_FILE_DOMAIN}}`), matching Portainer/N8N/Firefly III.
- Both services were just exposed publicly in #136; this makes the dashboard usable from outside the LAN.
- `ping` targets stay on the internal docker hostnames so the liveness check still works.

## Test plan
- [ ] CI gate passes (no `cloud/**` change → tf-checks skipped)
- [ ] After merge: `./scripts/sync_infra.sh` (no VERSION bump needed — homepage configs are bind-mounted), then `ssh pi 'docker service update --force infra_dashboard'` to make the dashboard re-read services.yaml
- [ ] Open `https://homepage.giocaizzi.xyz`, click Grafana and Greenhouse tiles, confirm both route through CF Access to upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)