### PR TITLE
fix(cloud): enable Managed OAuth + DCR on MCP portal apps

### DIFF
--- a/cloud/main.tf
+++ b/cloud/main.tf
@@ -681,6 +681,19 @@ resource "cloudflare_zero_trust_access_application" "greenhouse_mcp_portal" {
   type       = "self_hosted"
   name       = "greenhouse-mcp.${var.zone_name}"
   domain     = "greenhouse-mcp.${var.zone_name}"
+
+  # Managed OAuth: lets non-browser MCP clients (Claude.ai) auth via OAuth2+DCR
+  # instead of a 302 browser redirect. Allowlist Claude's DCR callback URIs.
+  oauth_configuration = {
+    enabled = true
+    dynamic_client_registration = {
+      enabled = true
+      allowed_uris = [
+        "https://claude.ai/api/mcp/auth_callback",
+        "https://claude.com/api/mcp/auth_callback",
+      ]
+    }
+  }
   policies = [
     {
       id         = cloudflare_zero_trust_access_policy.greenhouse_users.id
@@ -769,6 +782,19 @@ resource "cloudflare_zero_trust_access_application" "firefly_mcp_portal" {
   type       = "self_hosted"
   name       = "firefly-mcp.${var.zone_name}"
   domain     = "firefly-mcp.${var.zone_name}"
+
+  # Managed OAuth: lets non-browser MCP clients (Claude.ai) auth via OAuth2+DCR
+  # instead of a 302 browser redirect. Allowlist Claude's DCR callback URIs.
+  oauth_configuration = {
+    enabled = true
+    dynamic_client_registration = {
+      enabled = true
+      allowed_uris = [
+        "https://claude.ai/api/mcp/auth_callback",
+        "https://claude.com/api/mcp/auth_callback",
+      ]
+    }
+  }
   policies = [
     {
       id         = cloudflare_zero_trust_access_policy.firefly_users.id
@@ -832,6 +858,19 @@ resource "cloudflare_zero_trust_access_application" "n8n_mcp_portal" {
   type       = "self_hosted"
   name       = "n8n-mcp.${var.zone_name}"
   domain     = "n8n-mcp.${var.zone_name}"
+
+  # Managed OAuth: lets non-browser MCP clients (Claude.ai) auth via OAuth2+DCR
+  # instead of a 302 browser redirect. Allowlist Claude's DCR callback URIs.
+  oauth_configuration = {
+    enabled = true
+    dynamic_client_registration = {
+      enabled = true
+      allowed_uris = [
+        "https://claude.ai/api/mcp/auth_callback",
+        "https://claude.com/api/mcp/auth_callback",
+      ]
+    }
+  }
   policies = [
     {
       id         = cloudflare_zero_trust_access_policy.n8n_users.id


### PR DESCRIPTION
Claude.ai DCR failed (`couldn't register with sign-in service`): the portal Access apps returned **302** (browser redirect) instead of an OAuth flow because Managed OAuth wasn't enabled.

Enables `oauth_configuration { enabled = true, dynamic_client_registration { enabled = true, allowed_uris = [claude.ai + claude.com /api/mcp/auth_callback] } }` on all three `*_mcp_portal` apps so non-browser MCP clients can register + authenticate via OAuth 2.0.

Post-apply expectation: portal hostnames return **401 + WWW-Authenticate** (OAuth discovery) instead of 302. Refs [claude-ai-mcp#410](https://github.com/anthropics/claude-ai-mcp/issues/410).

🤖 Generated with [Claude Code](https://claude.com/claude-code)