### PR TITLE
feat(workers): finalize Claude.ai MCP connectors (WAF fix, PKCE, docs)

### DIFF
--- a/workers/mcp-connector/README.md
+++ b/workers/mcp-connector/README.md
@@ -1,0 +1,177 @@
+# 🔌 mcp-connector — Claude.ai MCP connectors for self-hosted servers
+
+A single Cloudflare Worker codebase, deployed once per upstream, that makes a
+self-hosted MCP server connectable from **Claude.ai (web + Desktop)** as a custom
+connector — with OAuth login gated to the owner's Google identity and the origin
+never exposed unauthenticated.
+
+Live connectors:
+
+| Service    | Connector URL (add this in Claude.ai)                          | Upstream MCP endpoint (on the Pi)                  |
+|------------|----------------------------------------------------------------|---------------------------------------------------|
+| Greenhouse | `https://mcp-connector-greenhouse.giocaizzi.workers.dev/mcp`   | `https://greenhouse.giocaizzi.xyz/mcp`            |
+| Firefly III| `https://mcp-connector-firefly.giocaizzi.workers.dev/mcp`      | `https://firefly.giocaizzi.xyz/api/v1/mcp`        |
+| n8n        | `https://mcp-connector-n8n.giocaizzi.workers.dev/mcp`          | `https://n8n.giocaizzi.xyz/mcp-server/http`       |
+
+---
+
+## 🚀 Quick Start
+
+Add a connector in Claude.ai → **Settings → Connectors → Add custom connector**,
+paste the connector URL above, and complete the Google login. That's it — Claude.ai
+self-registers (DCR), runs OAuth, and starts an MCP session.
+
+To deploy/operate the Workers yourself, see [Deployment](#-deployment).
+
+---
+
+## 📦 Architecture
+
+The Worker is **both** the OAuth 2.1 authorization server **and** the MCP resource,
+on **one origin**. That single-origin property is the whole point (see
+[Why a Worker](#-why-a-worker-design-rationale)). Login is delegated to Google;
+the `/mcp` route is a token-gated reverse proxy to the Pi.
+
+```mermaid
+sequenceDiagram
+    participant C as Claude.ai
+    participant W as Worker (workers.dev)
+    participant G as Google
+    participant P as Upstream MCP (Pi, via CF Tunnel)
+
+    C->>W: POST /mcp (no token)
+    W-->>C: 401 + WWW-Authenticate (resource_metadata)
+    C->>W: GET /.well-known/* , POST /register (DCR)
+    C->>W: GET /authorize (PKCE S256)
+    W->>G: redirect to Google login
+    G->>W: GET /callback (code)
+    W->>W: verify email ∈ ALLOWED_EMAILS
+    W-->>C: redirect with auth code
+    C->>W: POST /token  → access token
+    C->>W: POST /mcp (Bearer worker-token)
+    W->>P: proxy + inject CF-Access headers + UPSTREAM_BEARER
+    P-->>W: MCP response (JSON / SSE)
+    W-->>C: streamed back
+```
+
+**Files**
+
+| File                | Role                                                                       |
+|---------------------|----------------------------------------------------------------------------|
+| `src/index.ts`      | Wires `OAuthProvider` (apiRoute `/mcp`, Google default handler).            |
+| `src/google-handler.ts` | `/authorize` → Google; `/callback` → email allowlist → complete auth.   |
+| `src/proxy.ts`      | Token-gated `/mcp` reverse proxy; injects upstream auth; streams response.  |
+| `src/env.ts`        | Typed bindings (vars + secrets + KV + OAuthProvider).                       |
+| `wrangler.jsonc`    | One `env.<service>` per upstream (name, vars, KV id).                       |
+| `deploy.sh`         | Idempotent deploy + secret-setting helper (pulls CF Access creds from TF).  |
+
+---
+
+## 🔐 Security model
+
+Three independent gates protect the Pi origin; all must pass:
+
+1. **Identity (who):** OAuth login via Google, restricted to `ALLOWED_EMAILS`.
+   Only the owner can obtain a Worker access token.
+2. **Cloudflare Access (edge):** the upstream hostname sits behind a path-scoped
+   Access app. The Worker carries `CF-Access-Client-Id/Secret` for a `bypass`
+   policy; no one else traverses Access to the origin.
+3. **App bearer (origin):** the MCP server itself validates `Authorization:
+   Bearer <UPSTREAM_BEARER>` (Firefly Passport PAT / n8n MCP token / greenhouse
+   token). Fail-closed.
+
+Secrets never touch Claude.ai or the browser — the Worker swaps Claude's OAuth
+token for the upstream credentials server-side. The CF Access service-token
+credentials and the `<svc>_mcp_policy` bypass apps are defined in `cloud/` (Terraform).
+
+---
+
+## 🔑 Secrets
+
+Per-service, set with `wrangler secret put <NAME> --env <service>` (write-only;
+never in `wrangler.jsonc`, never in argv with the value inline):
+
+| Secret                  | Value                                                                  |
+|-------------------------|------------------------------------------------------------------------|
+| `GOOGLE_CLIENT_ID`      | Google OAuth "Web application" client id (shared across all three).    |
+| `GOOGLE_CLIENT_SECRET`  | …its secret (shared).                                                  |
+| `UPSTREAM_BEARER`       | App-level bearer the upstream validates (per service — see below).      |
+| `CF_ACCESS_CLIENT_ID`   | `terraform -chdir=cloud output -raw claude_<svc>_mcp_client_id`.        |
+| `CF_ACCESS_CLIENT_SECRET` | `terraform -chdir=cloud output -raw claude_<svc>_mcp_client_secret`. |
+
+`UPSTREAM_BEARER` per service:
+- **firefly** — a Firefly III Personal Access Token (Profile → OAuth → Personal Access Tokens).
+- **n8n** — the bearer of the n8n MCP Server Trigger node.
+- **greenhouse** — the greenhouse `MCP_TOKEN`.
+
+**Google OAuth client** — one "Web application" client, with all three callback
+URLs registered as Authorized redirect URIs:
+```
+https://mcp-connector-greenhouse.giocaizzi.workers.dev/callback
+https://mcp-connector-firefly.giocaizzi.workers.dev/callback
+https://mcp-connector-n8n.giocaizzi.workers.dev/callback
+```
+
+---
+
+## ⚙️ Configuration
+
+Non-secret, per-service `vars` live in `wrangler.jsonc`:
+
+- `SERVICE_NAME` — display/log label.
+- `UPSTREAM_URL` — the **full** upstream MCP endpoint (path included).
+- `ALLOWED_EMAILS` — comma-separated login allowlist.
+
+Each env also binds a dedicated **KV namespace** (`OAUTH_KV`) that stores OAuth
+grants/tokens. KV ids are committed in `wrangler.jsonc`; create new ones with
+`wrangler kv namespace create OAUTH_KV --env <service>`.
+
+---
+
+## 🚢 Deployment
+
+```bash
+cd workers/mcp-connector
+npm install
+npx wrangler login
+
+# guided: creates KV (if needed), deploys each env, sets secrets
+./deploy.sh
+
+# or per service
+npx wrangler deploy --env <greenhouse|firefly|n8n>
+npm run typecheck
+```
+
+**Logs / debugging:** `npx wrangler tail --env <service> --format pretty`. The
+proxy logs a one-line `warn` on any non-2xx upstream response (status +
+content-type, never the body) — enough to distinguish an origin WAF block
+(`403 text/plain`), a bad bearer (`401`), and an app error.
+
+---
+
+## 💡 Why a Worker (design rationale)
+
+The earlier attempt used Cloudflare Access **"MCP Server Portals."** They deployed
+and were OAuth-compliant, but Claude.ai web/Desktop **could not complete a session**
+because the portal's authorization server lived on a *separate* host
+(`*.cloudflareaccess.com`) from the MCP resource. Claude.ai's connector expects the
+authorization server and the resource on the **same origin** (and trips Anthropic
+bug #291 otherwise). The Worker collapses both onto one `workers.dev` origin, which
+is exactly what Claude.ai handles — proven working for all three connectors.
+
+### ⚠️ Gotcha: don't forward the browser's headers to the origin
+
+Claude.ai's `/mcp` requests carry a large browser/SDK header set (`User-Agent`,
+`sec-*`, `x-stainless-*`, tracing…). Forwarding that wholesale to a
+Cloudflare-proxied origin trips a **WAF managed rule** → `403 "Your request was
+blocked."`, which Claude.ai surfaces as *"Authorization with the MCP server failed."*
+`proxy.ts` therefore forwards only an **allowlist** of MCP-required headers
+(`content-type`, `accept`, `mcp-session-id`, `mcp-protocol-version`,
+`last-event-id`) plus the injected auth and a stable `User-Agent`.
+
+### Tool-name limit
+
+Claude.ai rejects tool names longer than **64 characters**. An upstream whose MCP
+tool names exceed that will connect but fail to load tools. (greenhouse hit this —
+tracked in `giocaizzi/greenhouse#62`; the connector itself is fine.)

--- a/workers/mcp-connector/deploy.sh
+++ b/workers/mcp-connector/deploy.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Deploy + configure the mcp-connector Workers (one per upstream MCP server).
+#
+# PREREQS you must do first (cannot be automated):
+#   1. npx wrangler login                 # interactive browser OAuth
+#   2. A Google OAuth "Web application" client (Client ID + secret).
+#      Its redirect URIs are the <worker-url>/callback printed by this script —
+#      run the script once to learn the URLs, register them in the Google
+#      client, then re-run and supply the Google credentials.
+#
+# The CF Access service-token credentials are pulled automatically from
+# `terraform output` (cloud/), so you never handle them. You are prompted only
+# for the Google client creds (shared) and each service's UPSTREAM_BEARER.
+#
+# Idempotent: re-runnable. KV namespaces are created once; secrets you skip
+# (press Enter) are left unchanged.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CLOUD_DIR="../../cloud"
+ENVS=(greenhouse firefly n8n)
+
+# terraform output name of each service's CF Access service-token id/secret
+declare -A CF_ID=(
+  [greenhouse]=claude_greenhouse_mcp_client_id
+  [firefly]=claude_firefly_mcp_client_id
+  [n8n]=claude_n8n_mcp_client_id
+)
+declare -A CF_SECRET=(
+  [greenhouse]=claude_greenhouse_mcp_client_secret
+  [firefly]=claude_firefly_mcp_client_secret
+  [n8n]=claude_n8n_mcp_client_secret
+)
+
+wr() { npx wrangler "$@"; }
+tf_out() { terraform -chdir="$CLOUD_DIR" output -raw "$1"; }
+put_secret() { printf '%s' "$2" | wr secret put "$1" --env "$3" >/dev/null; echo "    set $1"; }
+
+wr whoami >/dev/null 2>&1 || { echo "Not logged in — run: npx wrangler login"; exit 1; }
+
+read -rp "Google OAuth Client ID (Enter to skip): " GOOGLE_ID
+GOOGLE_SECRET=""
+if [ -n "$GOOGLE_ID" ]; then
+  read -rsp "Google OAuth Client secret: " GOOGLE_SECRET; echo
+fi
+
+for env in "${ENVS[@]}"; do
+  echo "=== $env ==="
+  ph="REPLACE_WITH_$(echo "$env" | tr '[:lower:]' '[:upper:]')_KV_ID"
+  if grep -q "$ph" wrangler.jsonc; then
+    echo "  creating KV namespace..."
+    id=$(wr kv namespace create OAUTH_KV --env "$env" 2>&1 | grep -oiE '[a-f0-9]{32}' | head -1)
+    [ -n "$id" ] || { echo "  KV create failed"; exit 1; }
+    sed -i '' "s/$ph/$id/" wrangler.jsonc
+    echo "  KV id: $id"
+  fi
+
+  echo "  deploying..."
+  wr deploy --env "$env"
+
+  echo "  setting secrets..."
+  put_secret CF_ACCESS_CLIENT_ID     "$(tf_out "${CF_ID[$env]}")"     "$env"
+  put_secret CF_ACCESS_CLIENT_SECRET "$(tf_out "${CF_SECRET[$env]}")" "$env"
+  [ -n "$GOOGLE_ID" ]     && put_secret GOOGLE_CLIENT_ID     "$GOOGLE_ID"     "$env"
+  [ -n "$GOOGLE_SECRET" ] && put_secret GOOGLE_CLIENT_SECRET "$GOOGLE_SECRET" "$env"
+  read -rsp "  UPSTREAM_BEARER for $env (Enter to skip): " bearer; echo
+  [ -n "$bearer" ] && put_secret UPSTREAM_BEARER "$bearer" "$env"
+done
+
+echo
+echo "=== Google OAuth client → Authorized redirect URIs (add all three) ==="
+for env in "${ENVS[@]}"; do echo "  https://mcp-connector-$env.<your-subdomain>.workers.dev/callback"; done
+echo "=== Claude.ai → Settings → Connectors → Add custom connector (URL) ==="
+for env in "${ENVS[@]}"; do echo "  https://mcp-connector-$env.<your-subdomain>.workers.dev/mcp"; done
+echo
+echo "Your <your-subdomain> is shown in the 'Deployed to' URL printed by wrangler above."

--- a/workers/mcp-connector/package-lock.json
+++ b/workers/mcp-connector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mcp-connector",
       "version": "0.1.0",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.0.5"
+        "@cloudflare/workers-oauth-provider": "^0.8.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250601.0",
@@ -128,18 +128,16 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.0.5.tgz",
-      "integrity": "sha512-t1x5KAzsubCvb4APnJ93z407X1x7SGj/ga5ziRnwIb/iLy4PMkT/hgd1y5z7Bbsdy5Fy6mywhCP4lym24bX66w==",
-      "license": "MIT",
-      "dependencies": {
-        "@cloudflare/workers-types": "^4.20250311.0"
-      }
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.8.0.tgz",
+      "integrity": "sha512-Vb2mjT9R+rLS9FcHgd5+ab4u7SP0ZB7x7t9M94JNMdN5e2ogRf3NOUCPW6NhBCTPwKu36VrfrYPPNGjOek4VYQ==",
+      "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {
       "version": "4.20260613.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260613.1.tgz",
       "integrity": "sha512-1mrgjE6epolwBhroeGAp5ud5H6Vyi6tl1o/NP0T4rXJ8bmEjmhHnbCzAhHTDHV0PIeip43wcuzHKJarvaGTaUA==",
+      "dev": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/workers/mcp-connector/package.json
+++ b/workers/mcp-connector/package.json
@@ -13,7 +13,7 @@
     "tail:greenhouse": "wrangler tail --env greenhouse"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.0.5"
+    "@cloudflare/workers-oauth-provider": "^0.8.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250601.0",

--- a/workers/mcp-connector/src/index.ts
+++ b/workers/mcp-connector/src/index.ts
@@ -25,4 +25,6 @@ export default new OAuthProvider({
   tokenEndpoint: "/token",
   // Claude.ai self-registers via Dynamic Client Registration (RFC 7591).
   clientRegistrationEndpoint: "/register",
+  // Claude.ai requires PKCE S256; reject the weaker `plain` method.
+  allowPlainPKCE: false,
 });

--- a/workers/mcp-connector/src/proxy.ts
+++ b/workers/mcp-connector/src/proxy.ts
@@ -12,16 +12,17 @@
  */
 import type { Env, Props } from "./env";
 
-// Hop-by-hop / connection headers that must not be forwarded.
-const STRIP_REQUEST_HEADERS = [
-  "authorization",
-  "cf-access-client-id",
-  "cf-access-client-secret",
-  "host",
-  "cf-connecting-ip",
-  "cf-ray",
-  "x-forwarded-host",
-  "x-forwarded-proto",
+// Forward ONLY the headers the MCP streamable-HTTP transport needs. The inbound
+// request from Claude.ai carries a large browser/SDK header set (User-Agent,
+// sec-*, x-stainless-*, tracing, etc.); blindly proxying that to a
+// Cloudflare-proxied origin trips WAF managed rules ("Your request was
+// blocked", 403). An allowlist keeps the subrequest clean and predictable.
+const FORWARD_REQUEST_HEADERS = [
+  "content-type",
+  "accept",
+  "mcp-session-id",
+  "mcp-protocol-version",
+  "last-event-id",
 ];
 
 export const proxyHandler = {
@@ -34,11 +35,16 @@ export const proxyHandler = {
     // UPSTREAM_URL already carries the full path (e.g. .../mcp); preserve query string.
     const target = env.UPSTREAM_URL + inUrl.search;
 
-    const headers = new Headers(request.headers);
-    for (const h of STRIP_REQUEST_HEADERS) headers.delete(h);
+    const headers = new Headers();
+    for (const h of FORWARD_REQUEST_HEADERS) {
+      const v = request.headers.get(h);
+      if (v) headers.set(h, v);
+    }
     headers.set("authorization", `Bearer ${env.UPSTREAM_BEARER}`);
     headers.set("cf-access-client-id", env.CF_ACCESS_CLIENT_ID);
     headers.set("cf-access-client-secret", env.CF_ACCESS_CLIENT_SECRET);
+    // Stable, benign User-Agent so the origin's WAF sees a predictable client.
+    headers.set("user-agent", "mcp-connector/1.0 (+cloudflare-workers)");
     // Trace which authenticated user drove the call (best-effort).
     if (ctx.props?.email) headers.set("x-mcp-connector-user", ctx.props.email);
 
@@ -54,6 +60,16 @@ export const proxyHandler = {
     }
 
     const upstream = await fetch(target, init);
+
+    // Surface non-2xx upstream responses in `wrangler tail` (status + type only,
+    // never the body — it may carry data). Enough to tell apart an origin WAF
+    // block (403 text/plain), a bad bearer (401), and an app error.
+    if (!upstream.ok) {
+      console.warn(
+        `[proxy] ${env.SERVICE_NAME} upstream ${upstream.status} ` +
+          `(${request.method} ${inUrl.pathname}) ct=${upstream.headers.get("content-type")}`,
+      );
+    }
 
     // Stream the response back unchanged (supports SSE / chunked MCP responses).
     const outHeaders = new Headers(upstream.headers);

--- a/workers/mcp-connector/wrangler.jsonc
+++ b/workers/mcp-connector/wrangler.jsonc
@@ -1,50 +1,60 @@
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  // Single-origin OAuth + MCP reverse-proxy. One codebase, deployed three times
-  // (one Worker per upstream MCP server) via wrangler environments.
-  //
-  // Each env gets its own workers.dev hostname, its own KV namespace, and its
-  // own secrets. Fill the KV `id`s after `wrangler kv namespace create` (see README).
-  "name": "mcp-connector",
-  "main": "src/index.ts",
-  "compatibility_date": "2025-06-01",
-  "workers_dev": true,
-  "observability": { "enabled": true },
-
-  // No top-level deploy target — always deploy with --env <service>.
-  "env": {
-    "greenhouse": {
-      "name": "mcp-connector-greenhouse",
-      "vars": {
-        "SERVICE_NAME": "Greenhouse",
-        "UPSTREAM_URL": "https://greenhouse.giocaizzi.xyz/mcp",
-        "ALLOWED_EMAILS": "giocaizzi@gmail.com"
-      },
-      "kv_namespaces": [
-        { "binding": "OAUTH_KV", "id": "REPLACE_WITH_GREENHOUSE_KV_ID" }
-      ]
-    },
-    "firefly": {
-      "name": "mcp-connector-firefly",
-      "vars": {
-        "SERVICE_NAME": "Firefly III",
-        "UPSTREAM_URL": "https://firefly.giocaizzi.xyz/api/v1/mcp",
-        "ALLOWED_EMAILS": "giocaizzi@gmail.com"
-      },
-      "kv_namespaces": [
-        { "binding": "OAUTH_KV", "id": "REPLACE_WITH_FIREFLY_KV_ID" }
-      ]
-    },
-    "n8n": {
-      "name": "mcp-connector-n8n",
-      "vars": {
-        "SERVICE_NAME": "n8n",
-        "UPSTREAM_URL": "https://n8n.giocaizzi.xyz/mcp-server/http",
-        "ALLOWED_EMAILS": "giocaizzi@gmail.com"
-      },
-      "kv_namespaces": [
-        { "binding": "OAUTH_KV", "id": "REPLACE_WITH_N8N_KV_ID" }
-      ]
-    }
-  }
+	"$schema": "node_modules/wrangler/config-schema.json",
+	// Single-origin OAuth + MCP reverse-proxy. One codebase, deployed three times
+	// (one Worker per upstream MCP server) via wrangler environments.
+	//
+	// Each env gets its own workers.dev hostname, its own KV namespace, and its
+	// own secrets. Fill the KV `id`s after `wrangler kv namespace create` (see README).
+	"name": "mcp-connector",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-06-01",
+	"workers_dev": true,
+	"observability": {
+		"enabled": true
+	},
+	// No top-level deploy target — always deploy with --env <service>.
+	"env": {
+		"greenhouse": {
+			"name": "mcp-connector-greenhouse",
+			"vars": {
+				"SERVICE_NAME": "Greenhouse",
+				"UPSTREAM_URL": "https://greenhouse.giocaizzi.xyz/mcp",
+				"ALLOWED_EMAILS": "giocaizzi@gmail.com"
+			},
+			"kv_namespaces": [
+				{
+					"binding": "OAUTH_KV",
+					"id": "07a2c01840b44f96966e2691dbac4d9e"
+				}
+			]
+		},
+		"firefly": {
+			"name": "mcp-connector-firefly",
+			"vars": {
+				"SERVICE_NAME": "Firefly III",
+				"UPSTREAM_URL": "https://firefly.giocaizzi.xyz/api/v1/mcp",
+				"ALLOWED_EMAILS": "giocaizzi@gmail.com"
+			},
+			"kv_namespaces": [
+				{
+					"binding": "OAUTH_KV",
+					"id": "90e16176346a472d8375b4c310868f40"
+				}
+			]
+		},
+		"n8n": {
+			"name": "mcp-connector-n8n",
+			"vars": {
+				"SERVICE_NAME": "n8n",
+				"UPSTREAM_URL": "https://n8n.giocaizzi.xyz/mcp-server/http",
+				"ALLOWED_EMAILS": "giocaizzi@gmail.com"
+			},
+			"kv_namespaces": [
+				{
+					"binding": "OAUTH_KV",
+					"id": "20c5002a26414d7d94cace25ddbf637a"
+				}
+			]
+		}
+	}
 }


### PR DESCRIPTION
## Summary
All three Claude.ai custom connectors — **greenhouse, firefly, n8n** — now work end-to-end in Claude.ai web/Desktop through the single-origin OAuth+MCP Worker (`workers/mcp-connector`). This ships the delta that made firefly/n8n connect and documents the whole thing.

## Root cause fixed
firefly/n8n failed with *"Authorization with the MCP server failed"*. Worker logs showed the upstream returning `403 text/plain "Your request was blocked."` — a **Cloudflare WAF managed rule**, not the app. The proxy was forwarding Claude.ai's full browser/SDK header set (`User-Agent`, `sec-*`, `x-stainless-*`, tracing…) to a CF-proxied origin, which tripped the rule. A direct `curl` to the same endpoint passed — confirming it was the header soup.

## Changes
- **proxy**: forward only an allowlist of MCP-required headers (`content-type`, `accept`, `mcp-session-id`, `mcp-protocol-version`, `last-event-id`) + injected auth + a stable `User-Agent`; warn-log non-2xx upstream responses (status + content-type only, never body).
- **index**: `allowPlainPKCE: false` (Claude.ai uses S256).
- **deps**: `@cloudflare/workers-oauth-provider` `0.0.5 → 0.8.0` (serves RFC 9728 protected-resource metadata required for discovery).
- **wrangler.jsonc**: commit per-env KV namespace ids.
- **docs**: `README.md` (architecture, security model, secrets, deployment, single-origin + header-allowlist rationale) and `deploy.sh` helper.

## Verification
- firefly ✅ and n8n ✅ connect and run tools in Claude.ai.
- greenhouse connects; its tool names exceed Claude.ai's 64-char cap → `giocaizzi/greenhouse#62` (connector itself proven fine).
- All three Workers deployed; typecheck clean.

## Follow-ups (outside this PR)
- Delete dead `cloud-production` env secrets `FIREFLY_MCP_TOKEN` / `GREENHOUSE_MCP_TOKEN` / `N8N_MCP_TOKEN` (portal-era, now unreferenced).
- Fix greenhouse tool-name lengths (#62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)