### PR TITLE
fix(greenhouse): repair v3.0.0 healthcheck + wire session-auth secrets

### DIFF
--- a/services/greenhouse/README.md
+++ b/services/greenhouse/README.md
@@ -50,10 +50,34 @@ Tuya Cloud (sensors)
 | `greenhouse_tuya_client_id` | `echo -n '<your client id>' \| docker secret create greenhouse_tuya_client_id -` |
 | `greenhouse_tuya_client_secret` | `echo -n '<your client secret>' \| docker secret create greenhouse_tuya_client_secret -` |
 | `greenhouse_mcp_token` | `openssl rand -hex 32 \| docker secret create greenhouse_mcp_token -` |
+| `greenhouse_auth_secret_key` | `openssl rand -hex 32 \| docker secret create greenhouse_auth_secret_key -` |
+| `greenhouse_auth_admin_password` | `openssl rand -base64 24 \| docker secret create greenhouse_auth_admin_password -` |
 
 Tuya values come from the Tuya IoT Cloud project ("Authorization Key").
 The MCP token is opaque — generate any high-entropy string and share it
 with MCP clients via `Authorization: Bearer <token>`.
+
+### Session auth (v3.0.0+)
+
+Since upstream **v3.0.0** every `/api/v1` route (except `/auth/login` and
+`/.well-known/*`) and every web page requires a login. Two secrets back it:
+
+- `greenhouse_auth_secret_key` — HS256 key that signs the session JWT.
+- `greenhouse_auth_admin_password` — bootstraps the admin user on the **first**
+  v3.0.0 boot (username is `admin`, set via `GREENHOUSE_AUTH_ADMIN_USERNAME`).
+  Save the generated value before creating the secret; it is the login password.
+
+> **MCP is unaffected.** `/mcp` keeps its own `greenhouse_mcp_token` bearer gate
+> (`require_user` also accepts that token), so MCP tool calls work without a
+> session. The two auth surfaces are independent — session auth for humans, the
+> bearer token for machines.
+
+> **Cookie is non-secure on purpose.** The LAN serves plain HTTP at
+> `greenhouse.home`, so a `Secure` cookie would never be sent there and would
+> break LAN login. Public access (`greenhouse.giocaizzi.xyz`) is HTTPS via the
+> Cloudflare tunnel + CF Access, and the non-secure cookie still rides that
+> encrypted path. Public browser users therefore see **two** prompts: the CF
+> Access email gate, then the app login.
 
 ---
 
@@ -70,6 +94,8 @@ Tunables in `docker-compose.yml` `environment:`:
 | `IRRIGATION_CHECK_CRON_HOURS` | `*/6` | Cron hour spec for `check_all` (replaces deprecated `IRRIGATION_CHECK_INTERVAL_HOURS`; engine cooldown still gates actuation) |
 | `IRRIGATION_WEATHER_LAT` / `_LON` | `45.464` / `9.189` | Open-Meteo coordinates for the precipitation-skip rule |
 | `IRRIGATION_ENABLE_SCHEDULER` | `true` | Disable to freeze the system without stopping the stack |
+| `IRRIGATION_AUTH_ENABLED` | `true` | Session auth gate (v3.0.0+). `false` opts out — dev/migration only |
+| `GREENHOUSE_AUTH_ADMIN_USERNAME` | `admin` | Bootstrap admin username (password is a secret) |
 
 The local key for each irrigator is fetched from the Tuya Cloud API at
 runtime — only the client ID + secret are needed as Swarm secrets.

--- a/services/greenhouse/docker-compose.yml
+++ b/services/greenhouse/docker-compose.yml
@@ -64,6 +64,14 @@ secrets:
   mcp_token:
     external: true
     name: greenhouse_mcp_token
+  # Session auth (v3.0.0+). HS256 key signs the session JWT; admin password
+  # bootstraps the first user on initial boot. Username is non-sensitive (env).
+  auth_secret_key:
+    external: true
+    name: greenhouse_auth_secret_key
+  auth_admin_password:
+    external: true
+    name: greenhouse_auth_admin_password
 
 # =============================================================================
 # Services
@@ -90,10 +98,22 @@ services:
       # Weather (Milan defaults — override per location)
       - IRRIGATION_WEATHER_LAT=45.464
       - IRRIGATION_WEATHER_LON=9.189
+      # Session auth (v3.0.0+). Every /api/v1 route (except /auth/login and
+      # /.well-known/*) and every web page requires a login. MCP is unaffected
+      # — it keeps its own GREENHOUSE_MCP_TOKEN bearer (require_user also
+      # accepts that token). Cookie stays NON-secure: the LAN serves plain HTTP
+      # at greenhouse.home, so a Secure cookie would never be sent there and
+      # would break LAN login. Public access (greenhouse.giocaizzi.xyz) is HTTPS
+      # via the Cloudflare tunnel + CF Access; the non-secure cookie still rides
+      # that encrypted path fine.
+      - IRRIGATION_AUTH_ENABLED=true
+      - GREENHOUSE_AUTH_ADMIN_USERNAME=admin
     secrets:
       - tuya_client_id
       - tuya_client_secret
       - mcp_token
+      - auth_secret_key
+      - auth_admin_password
     # Wrap secrets into env vars before exec'ing the server entrypoint.
     # The greenhouse image reads these directly from the environment (no
     # _FILE suffix support), so we export from /run/secrets. GREENHOUSE_MCP_TOKEN
@@ -105,18 +125,25 @@ services:
         export TUYA_CLIENT_ID=$$(cat /run/secrets/tuya_client_id)
         export TUYA_CLIENT_SECRET=$$(cat /run/secrets/tuya_client_secret)
         export GREENHOUSE_MCP_TOKEN=$$(cat /run/secrets/mcp_token)
+        export GREENHOUSE_AUTH_SECRET_KEY=$$(cat /run/secrets/auth_secret_key)
+        export GREENHOUSE_AUTH_ADMIN_PASSWORD=$$(cat /run/secrets/auth_admin_password)
         exec greenhouse-server
     volumes:
       - greenhouse_data:/app/data
     networks:
       - greenhouse_network
       - public_network
+    # Liveness probe hits the only unauthenticated GET that returns 200:
+    # /.well-known/oauth-protected-resource (root-mounted, no session required).
+    # Since v3.0.0 every /api/v1 route needs auth, so the old /api/v1/clusters
+    # probe returned 401 — still <500, so it reported "healthy" without ever
+    # exercising the app. The well-known route proves routing + app are alive.
     healthcheck:
       test:
         - "CMD"
         - "python"
         - "-c"
-        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/api/v1/clusters', timeout=3).status < 500 else 1)"
+        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/.well-known/oauth-protected-resource', timeout=3).status == 200 else 1)"
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Why

greenhouse **v3.0.0** turned on session auth — every `/api/v1` route now requires a login. The committed healthcheck probes `GET /api/v1/clusters`, which now returns **401**. `urllib.urlopen` *raises* `HTTPError` on 401, so the probe exits non-zero → Swarm marks the task unhealthy → **restart loop** → no healthy origin → CF 502 at the MCP connector.

This is why the stack crashlooped after the v3.0.0 image rolled out. (A direct `docker stack deploy` of the fix restored it temporarily, but any redeploy from this repo reverted it — hence this commit.)

## Changes

- **Healthcheck** → `GET /.well-known/oauth-protected-resource` (the only unauthenticated 200), asserting `== 200` so it proves the app is actually serving instead of masking a 401 as `<500 healthy`.
- **Wire session-auth secrets/env**: `greenhouse_auth_secret_key` + `greenhouse_auth_admin_password` (already created on the Pi), `IRRIGATION_AUTH_ENABLED=true`, `GREENHOUSE_AUTH_ADMIN_USERNAME=admin`. Entrypoint exports the two secrets.
- **Cookie stays non-secure** — LAN serves plain HTTP at `greenhouse.home`; public is HTTPS via the tunnel.
- **README**: new secrets, auth section, MCP-unaffected note.

`/mcp` is unaffected — it keeps its own `GREENHOUSE_MCP_TOKEN` bearer.

> Pairs with greenhouse PR #63 (app-side login-page render-loop fix → v3.0.1). This PR fixes the *deploy spec*; #63 fixes the *app*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)