### PR TITLE
chore(cloud): remove dead GitHub-webhook CF Access infra

### DIFF
--- a/cloud/main.tf
+++ b/cloud/main.tf
@@ -302,31 +302,6 @@ resource "cloudflare_zero_trust_access_policy" "greenhouse_users" {
   ]
 }
 
-# ============================================================================
-# Webhook Service Token and Bypass Policy for GitOps
-# ============================================================================
-
-# Create service token for GitHub webhook authentication
-resource "cloudflare_zero_trust_access_service_token" "github_webhook" {
-  account_id = var.cloudflare_account_id
-  name       = "github-webhooks"
-}
-
-# Create bypass policy for webhook endpoints
-resource "cloudflare_zero_trust_access_policy" "webhook_bypass" {
-  account_id = var.cloudflare_account_id
-  name       = "webhook-bypass"
-  decision   = "bypass"
-
-  include = [
-    {
-      service_token = {
-        token_id = cloudflare_zero_trust_access_service_token.github_webhook.id
-      }
-    }
-  ]
-}
-
 # Creates an Access application to control who can connect to the public hostname.
 resource "cloudflare_zero_trust_access_application" "n8n_policy" {
   account_id = var.cloudflare_account_id
@@ -341,7 +316,8 @@ resource "cloudflare_zero_trust_access_application" "n8n_policy" {
   ]
 }
 
-# Portainer access application with webhook bypass support
+# Portainer access application (email-gated; webhook deploys hit Portainer
+# locally from the Pi runner, so no service-token bypass is needed).
 resource "cloudflare_zero_trust_access_application" "portainer_policy" {
   account_id       = var.cloudflare_account_id
   type             = "self_hosted"
@@ -349,24 +325,10 @@ resource "cloudflare_zero_trust_access_application" "portainer_policy" {
   domain           = "portainer.${var.zone_name}"
   session_duration = "24h"
 
-  # Enable CORS for webhook requests
-  cors_headers = {
-    allowed_methods   = ["GET", "POST", "OPTIONS"]
-    allowed_origins   = ["*"] # GitHub webhook origins vary
-    allow_credentials = false
-    max_age           = 3600
-  }
-
   policies = [
-    # Webhook bypass policy (highest precedence) - allows service tokens to bypass auth
-    {
-      id         = cloudflare_zero_trust_access_policy.webhook_bypass.id
-      precedence = 1
-    },
-    # Regular user access policy
     {
       id         = cloudflare_zero_trust_access_policy.portainer_users.id
-      precedence = 2
+      precedence = 1
     }
   ]
 }

--- a/cloud/outputs.tf
+++ b/cloud/outputs.tf
@@ -74,21 +74,6 @@ output "backup_service_account_key" {
 }
 
 # ============================================================================
-# GitOps Webhook Outputs
-# ============================================================================
-
-output "github_webhook_client_id" {
-  description = "Client ID for GitHub webhook service token"
-  value       = cloudflare_zero_trust_access_service_token.github_webhook.client_id
-}
-
-output "github_webhook_client_secret" {
-  description = "Client Secret for GitHub webhook service token"
-  value       = cloudflare_zero_trust_access_service_token.github_webhook.client_secret
-  sensitive   = true
-}
-
-# ============================================================================
 # Claude Code MCP Outputs (per-endpoint, isolated blast radius)
 # ============================================================================
 

--- a/docs/gitops.md
+++ b/docs/gitops.md
@@ -106,8 +106,11 @@ Repo **secrets**:
 - `WEBHOOK_ID_<STACK>` — the webhook id per stack
   (`WEBHOOK_ID_N8N`, `WEBHOOK_ID_FIREFLY`, `WEBHOOK_ID_ADGUARD`, …)
 
-> The CF Access service token (`CF_ACCESS_CLIENT_ID/SECRET`) is **no longer used**
-> by this workflow — the call is local. Those secrets remain for other uses.
+Each service stack's GitOps auto-update must be set to **Webhook** (not Polling)
+in Portainer, so the Actions workflow is the single deploy trigger (no polling,
+no overlap). The old CF Access service-token webhook path (and its
+`github-webhooks` token / `webhook_bypass` policy) has been removed — the call
+is local from the Pi runner.
 
 Environment `pi-services` (Settings → Environments): create it; optional
 required reviewers.


### PR DESCRIPTION
Services deploy now runs on the Pi runner and calls Portainer locally, so the GitHub→Cloudflare→Portainer webhook path is dead. Removes the `github-webhooks` service token, `webhook_bypass` policy, the Portainer app CORS + bypass reference, and the two `github_webhook_client_*` outputs.

`terraform plan`: 0 to add, 3 to change, 2 to destroy (scoped — verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)