### PR TITLE
ci(cicd): relax pr-title scope to any lowercase token

### DIFF
--- a/.claude/hooks/conventional-commit-guard.sh
+++ b/.claude/hooks/conventional-commit-guard.sh
@@ -60,21 +60,23 @@ if subject.startswith(("fixup!", "squash!", "Merge ", "Revert ")):
 TYPES = "feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert"
 # Scope is MANDATORY (repo policy): main is squash-only and the PR title becomes
 # the commit subject release-please parses, so every subject must be
-# `type(scope): …`. Scope must be a release-please component or `repo` for
-# cross-cutting changes. See AGENTS.md "Pull requests & commit titles".
-SCOPES = "infra|cloud|workers|mcp-connector|adguard|ai|firefly|greenhouse|langfuse|n8n|ntfy|observability|openclaw|cicd|repo"
-pattern = rf"^({TYPES})\(({SCOPES})\)!?: .+"
+# `type(scope): …`. The scope is any lowercase token — release-please attributes
+# releases by file PATH, not scope, so the scope is advisory (prefer the component
+# name where one applies). See AGENTS.md "Pull requests & commit titles".
+SCOPE = r"[a-z][a-z0-9-]*"
+pattern = rf"^({TYPES})\({SCOPE}\)!?: .+"
 if re.match(pattern, subject):
     sys.exit(0)
 
 sys.stderr.write(
-    "Blocked: commit subject is not a Conventional Commit with a valid scope.\n\n"
+    "Blocked: commit subject is not a Conventional Commit with a mandatory scope.\n\n"
     f"  Subject: {subject!r}\n\n"
-    "Required: <type>(<scope>)[!]: <description>   (scope is MANDATORY)\n"
+    "Required: <type>(<scope>)[!]: <description>   (scope is MANDATORY, lowercase)\n"
     f"  type in  {{{TYPES.replace('|', ', ')}}}\n"
-    f"  scope in {{{SCOPES.replace('|', ', ')}}}  (release-please component, or `repo` for cross-cutting)\n"
+    "  scope: any lowercase token — a release-please component (infra, cloud, greenhouse, …)\n"
+    "         or a meta scope (repo, cicd, deps, code)\n"
     "  e.g. 'feat(greenhouse): add humidity sensor', 'fix(infra): correct nginx healthcheck',\n"
-    "       'ci(repo): add pr-title lint', 'chore(infra)!: drop legacy config' (! marks a breaking change)\n\n"
+    "       'chore(deps): bump actions/checkout', 'chore(infra)!: drop legacy config' (! = breaking)\n\n"
     "main is squash-only, so the PR title becomes the commit release-please parses;\n"
     "the type drives the version bump and the scope keeps attribution clear.\n"
 )

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -38,17 +38,21 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
+          # Conventional Commit type + a MANDATORY scope. The scope is any lowercase
+          # token (`[a-z][a-z0-9-]*`) — not an allowlist: release-please attributes
+          # releases by file PATH, not by scope, so the scope is advisory. An open
+          # vocabulary keeps the gate from rejecting bot/feature scopes (Dependabot's
+          # `deps`, `code`, `cicd`, …). Prefer the component name where one applies.
           types='feat|fix|perf|refactor|revert|docs|style|test|build|ci|chore'
-          scopes='infra|cloud|workers|mcp-connector|adguard|ai|firefly|greenhouse|langfuse|n8n|ntfy|observability|openclaw|cicd|repo'
-          re="^(${types})\((${scopes})\)!?: [a-z].*$"
+          re="^(${types})\([a-z][a-z0-9-]*\)!?: [a-z].*$"
           if [[ "$TITLE" =~ $re ]]; then
             echo "OK: $TITLE"
           else
-            echo "::error::PR title must be 'type(scope): description' with a mandatory scope."
+            echo "::error::PR title must be 'type(scope): description' with a mandatory lowercase scope."
             echo "  Title: $TITLE"
             echo "  type  in: ${types//|/, }"
-            echo "  scope in: ${scopes//|/, }  (release-please component, or 'repo' for cross-cutting)"
-            echo "  subject must start lowercase. e.g. 'feat(greenhouse): add humidity sensor',"
-            echo "                                      'ci(repo): add pr-title lint'"
+            echo "  scope: any lowercase token — a release-please component (infra, cloud, greenhouse, …),"
+            echo "         or a meta scope (repo, cicd, deps, code). Subject must start lowercase."
+            echo "  e.g. 'feat(greenhouse): add humidity sensor', 'chore(deps): bump actions/checkout'"
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,11 +284,9 @@ Six GitHub Actions workflows. Versioning/tagging (`release-please.yml`, `pr-titl
 **Every PR title and every commit subject MUST be `type(scope): description`** — a [Conventional Commit](https://www.conventionalcommits.org) **with a mandatory scope**. This is not optional. `main` is **squash-only** with `squash_merge_commit_title=PR_TITLE`, so **the PR title becomes the commit subject release-please parses on `main`**. A malformed or unscoped title silently misattributes — or drops — the release.
 
 - **`type`** ∈ `feat` · `fix` · `perf` · `refactor` · `revert` · `docs` · `style` · `test` · `build` · `ci` · `chore`. The type drives the bump: `feat` → MINOR, `fix`/`perf`/`refactor`/`revert` → PATCH, `feat!` or a `BREAKING CHANGE:` footer → MAJOR; `docs`/`style`/`test`/`build`/`ci`/`chore` → no bump.
-- **`scope`** (REQUIRED) ∈ exactly one of:
-  - `infra` — the infra stack (the **main `vX.Y.Z` line**, `infra/VERSION`).
-  - `cloud` · `workers`/`mcp-connector` · `adguard` · `ai` · `firefly` · `greenhouse` · `langfuse` · `n8n` · `ntfy` · `observability` · `openclaw` — the per-component **release-please packages** (`<scope>-vX.Y.Z`, `0.x` config tracks; the worker tags as `mcp-connector-vX.Y.Z`). Use the scope matching the path the PR touches, and keep each PR to a **single** component (release-please attributes by file path).
-  - `cicd` — CI/CD workflow & deploy changes (`.github/workflows/**`, deploy scripts). Touches no release package → produces no release.
-  - `repo` — other **cross-cutting** changes touching no release package: root docs, `scripts/`, `.gitignore`, repo tooling. Produces no release. (e.g. `docs(repo): …`, `chore(repo): …`.)
+- **`scope`** (REQUIRED) — any lowercase token (`[a-z][a-z0-9-]*`); **not an allowlist** (release-please attributes releases by file **path**, not scope, so the scope is advisory). Pick it to communicate *what changed*:
+  - a **release-please component** when the PR touches that path — `infra` (the **main `vX.Y.Z` line**, `infra/VERSION`), `cloud`, `mcp-connector` (`workers/`), or a service (`greenhouse`, `n8n`, …). Keep each PR to a **single** component so the version + changelog land on the right one.
+  - a **meta scope** for cross-cutting work that touches no component → no release: `cicd` (`.github/workflows/**`, deploy scripts), `repo` (root docs, `scripts/`, tooling), `deps` (dependency bumps), etc.
 - **`description`** — imperative, lowercase first word, no trailing period.
 - Breaking change: add `!` after the scope (`feat(greenhouse)!: …`) and/or a `BREAKING CHANGE:` footer.
 


### PR DESCRIPTION
Follow-up to #156. The scope allowlist rejected scopes actually in use — Dependabot's `deps`/`deps-dev` and feature scopes like `code` — so making `Validate PR title` a required check would have blocked #149/#154/#155.

release-please attributes by file **path**, not scope, so the scope is advisory. This keeps the **mandatory lowercase scope** but accepts any `[a-z][a-z0-9-]*` token (pr-title.yml, commit-guard hook, AGENTS.md). After this, `Validate PR title` is safe to add to the `main` ruleset.